### PR TITLE
♻️ Replace ClrDebug with ICorDebugSharp

### DIFF
--- a/src/SharpDbg.InMemory/SharpDbg.InMemory.csproj
+++ b/src/SharpDbg.InMemory/SharpDbg.InMemory.csproj
@@ -33,7 +33,7 @@
 		<!-- We must include all package references required by projects that we reference -->
 		<PackageReference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol" Version="18.0.10427.1" />
 		<PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-		<PackageReference Include="ClrDebug" Version="0.3.4" />
+		<PackageReference Include="ICorDebugSharp" Version="0.1.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 		<PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
 		<PackageReference Include="ZLinq" Version="1.5.6" />

--- a/src/SharpDbg.InMemory/SharpDbg.InMemory.csproj
+++ b/src/SharpDbg.InMemory/SharpDbg.InMemory.csproj
@@ -33,7 +33,7 @@
 		<!-- We must include all package references required by projects that we reference -->
 		<PackageReference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol" Version="18.0.10427.1" />
 		<PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-		<PackageReference Include="ICorDebugSharp" Version="0.1.0" />
+		<PackageReference Include="ICorDebugSharp" Version="0.1.1" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 		<PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
 		<PackageReference Include="ZLinq" Version="1.5.6" />

--- a/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
+++ b/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
@@ -8,9 +8,9 @@ namespace SharpDbg.Infrastructure;
 // https://github.com/lordmilko/ClrDebug/blob/5f46218f4b840ab8a94920623dc263b5f2334138/Samples/NetCore/Program.cs
 public static class ClrDebugExtensions
 {
-	public static CorDebug Mobile(DbgShim dbgShim, RemoteAttachInfo remoteAttachInfo)
+	public static ICorDebug Mobile(DbgShim dbgShim, RemoteAttachInfo remoteAttachInfo)
 	{
-		CorDebug corDebug = null!;
+		ICorDebug corDebug = null!;
 		// Requires ClrDebug 0.4.0, which unfortunately introduced an unrelated bug
 		// Uncomment once a release is available including this fix: https://github.com/lordmilko/ClrDebug/issues/26
 		// var result = Extensions.TryRegisterForRuntimeStartupRemotePort(dbgShim,
@@ -27,11 +27,11 @@ public static class ClrDebugExtensions
 	}
 
 	/// pass resumeDiagnosticSuspension true if the process was launched with the DOTNET_DefaultDiagnosticPortSuspend environment variable, and you wish for it to be resumed after RegisterForRuntimeStartup
-	public static CorDebug Automatic(DbgShim dbgshim, int pid, bool resumeDiagnosticSuspension = false)
+	public static ICorDebug Automatic(DbgShim dbgshim, int pid, bool resumeDiagnosticSuspension = false)
 	{
 		IntPtr unregisterToken = IntPtr.Zero;
 
-		CorDebug? cordebug = null;
+		ICorDebug? cordebug = null;
 		HRESULT hr = Cor.E_FAIL;
 		var wait = new AutoResetEvent(false);
 
@@ -83,7 +83,7 @@ public static class ClrDebugExtensions
 		//while (true) Thread.Sleep(1);
 	}
 
-	public static CorDebug Manual(DbgShim dbgshim, int pid)
+	public static ICorDebug Manual(DbgShim dbgshim, int pid)
 	{
 		/* If the process initializes the CLR before GetStartupNotificationEvent is called (e.g. because you were playing in the debugger between launching
 		 * the process and reaching this line of code) then WaitForSingleObject below will hang indefinitely. You can prevent this by starting the process suspended.

--- a/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
+++ b/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
@@ -32,7 +32,7 @@ public static class ClrDebugExtensions
 		IntPtr unregisterToken = IntPtr.Zero;
 
 		CorDebug? cordebug = null;
-		HRESULT hr = HRESULT.E_FAIL;
+		HRESULT hr = Cor.E_FAIL;
 		var wait = new AutoResetEvent(false);
 
 		try

--- a/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
+++ b/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
@@ -1,3 +1,6 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Ardalis.GuardClauses;
 using ICorDebugSharp;
 using Microsoft.Diagnostics.NETCore.Client;
@@ -5,10 +8,19 @@ using SharpDbg.Infrastructure.Debugger.Models;
 
 namespace SharpDbg.Infrastructure;
 
-// https://github.com/lordmilko/ClrDebug/blob/5f46218f4b840ab8a94920623dc263b5f2334138/Samples/NetCore/Program.cs
+// Originally based on https://github.com/lordmilko/ClrDebug/blob/5f46218f4b840ab8a94920623dc263b5f2334138/Samples/NetCore/Program.cs
 public static class ClrDebugExtensions
 {
-	public static ICorDebug Mobile(DbgShim dbgShim, RemoteAttachInfo remoteAttachInfo)
+	[UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+	public static unsafe void OnRuntimeStartup(void* pCorDebug, void* parameter, int hr)
+	{
+		var corDebug = ComInterfaceMarshaller<ICorDebug>.ConvertToManaged(pCorDebug);
+		Guard.Against.Null(_runtimeStartupTcs);
+		_runtimeStartupTcs.SetResult((corDebug, hr));
+	}
+	private static TaskCompletionSource<(ICorDebug? CorDebug, int Hr)>? _runtimeStartupTcs;
+
+	public static ICorDebug Mobile(RemoteAttachInfo remoteAttachInfo)
 	{
 		ICorDebug corDebug = null!;
 		// Requires ClrDebug 0.4.0, which unfortunately introduced an unrelated bug
@@ -27,13 +39,12 @@ public static class ClrDebugExtensions
 	}
 
 	/// pass resumeDiagnosticSuspension true if the process was launched with the DOTNET_DefaultDiagnosticPortSuspend environment variable, and you wish for it to be resumed after RegisterForRuntimeStartup
-	public static ICorDebug Automatic(DbgShim dbgshim, int pid, bool resumeDiagnosticSuspension = false)
+	public static async Task<ICorDebug> Automatic(int pid, bool resumeDiagnosticSuspension = false)
 	{
 		IntPtr unregisterToken = IntPtr.Zero;
 
 		ICorDebug? cordebug = null;
-		HRESULT hr = Cor.E_FAIL;
-		var wait = new AutoResetEvent(false);
+		int hr = Cor.COR_E_FAILFAST;
 
 		try
 		{
@@ -44,36 +55,28 @@ public static class ClrDebugExtensions
 			 * technically speaking there is the possibility of a race occurring even without us stepping in the debugger, but that's the risk you take when
 			 * you use RegisterForRuntimeStartup */
 
-			//Our DbgShim object will cache the last delegate passed to native code to prevent it being garbage collected.
-			//As such there is no need to GC.KeepAlive() anything
-			unregisterToken = dbgshim.RegisterForRuntimeStartup(pid, (pCordb, parameter, callbackHR) =>
+			if (_runtimeStartupTcs is not null) throw new InvalidOperationException("OnRuntimeStartup has already been registered. Only one registration is allowed at a time.");
+			_runtimeStartupTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+			unsafe
 			{
-				/* DbgShim provides two overloads of RegisterForRuntimeStartup: one that takes a PSTARTUP_CALLBACK and one
-				 * that takes a RuntimeStartupCallback. As it is not possible to easily marshal the ICorDebug parameter on the PSTARTUP_CALLBACK
-				 * in all scenarios (.NET Core is buggy and NativeAOT is impossible on non-Windows platforms) we work around this by defining an
-				 * RegisterForRuntimeStartup extension method that takes a "RuntimeStartupCallback" instead. This extension method defers to the "real"
-				 * RegisterForRuntimeStartup internally and handles the marshalling/wrapping of the ICorDebug interface for us. If the HRESULT parameter
-				 * passed to the callback is not S_OK, "pCordb" will be null. If the delegate type or delegate parameter types on the callback passed to
-				 * RegisterForRuntimeStartup have not been explicitly specified, the compiler can still figure out which RegisterForRuntimeStartup
-				 * overload to use based on the type of value "pCordb" is assigned to. */
-				cordebug = pCordb;
-
-				hr = callbackHR;
-
-				wait.Set();
-			});
+				var registerHr = DbgShim.RegisterForRuntimeStartup(checked((uint)pid), &OnRuntimeStartup, 0, out unregisterToken);
+				Marshal.ThrowExceptionForHR(registerHr);
+			}
 
 			if (resumeDiagnosticSuspension) DiagnosticClientResumeRuntime(pid);
 
-			wait.WaitOne();
+			var result = await _runtimeStartupTcs.Task.ConfigureAwait(false);
+			cordebug = result.CorDebug;
+			hr = result.Hr;
 		}
 		finally
 		{
-			if (unregisterToken != IntPtr.Zero) dbgshim.UnregisterForRuntimeStartup(unregisterToken);
+			if (unregisterToken != IntPtr.Zero) DbgShim.UnregisterForRuntimeStartup(unregisterToken);
+			_runtimeStartupTcs = null;
 		}
 
 		//if callbackHR was not S_OK, an error occurred while attempting to register for runtime startup
-		if (cordebug is null) throw new DebugException(hr);
+		if (cordebug is null) throw new InvalidOperationException($"Attempting to register for runtime startup failed: {hr}");
 
 		return cordebug;
 
@@ -83,57 +86,57 @@ public static class ClrDebugExtensions
 		//while (true) Thread.Sleep(1);
 	}
 
-	public static ICorDebug Manual(DbgShim dbgshim, int pid)
-	{
-		/* If the process initializes the CLR before GetStartupNotificationEvent is called (e.g. because you were playing in the debugger between launching
-		 * the process and reaching this line of code) then WaitForSingleObject below will hang indefinitely. You can prevent this by starting the process suspended.
-		 * This event is signalled by debugger.cpp!OpenStartupNotificationEvent() which is called by NotifyDebuggerOfStartup(). Immediately after the startup event
-		 * is signalled, the CLR waits on g_hContinueStartupEvent which is one of the three components that comprise the global CLR_ENGINE_METRICS g_CLREngineMetrics! */
-		var startupEvent = dbgshim.GetStartupNotificationEvent(pid);
-
-		//The event WaitForSingleObject is waiting on won't occur unless the process is resumed
-		//dbgshim.ResumeProcess(resumeHandle);
-
-		// //As stated above, if you started the process suspended, you need to resume the process otherwise the CLR will never be loaded.
-		// var waitResult = NativeMethods.WaitForSingleObject(startupEvent, -1);
-		//
-		// if (waitResult != 0)
-		//     throw new InvalidOperationException($"Failed to get startup event. Is the target process a .NET Core application? Wait Result: {waitResult}");
-
-		var enumResult = dbgshim.EnumerateCLRs(pid);
-
-		try
-		{
-			var runtime = enumResult.Items.Single();
-
-			//Version String is a comma delimited value containing dbiVersion, pidDebuggee, hmodTargetCLR
-			var versionStr = dbgshim.CreateVersionStringFromModule(pid, runtime.Path);
-
-			/* Cordb::CheckCompatibility seems to be the only place where our debugger version is actually used,
-			 * and it says that if the version is 4, its major version 4. Version 4.5 is treated as an "unrecognized future version"
-			 * and is assigned major version 5, which is wrong. Cordb::CheckCompatibility then calls CordbProcess::IsCompatibleWith
-			 * which doesn't actually seem to do anything either, despite what all the docs in it would imply. */
-			var cordebug = dbgshim.CreateDebuggingInterfaceFromVersionEx(CorDebugInterfaceVersion.CorDebugVersion_4_0, versionStr);
-			return cordebug;
-			//Initialize ICorDebug, setup our managed callback and attach to the existing process. We attach while the CLR is blocked waiting for the "continue" event to be called
-			//InitCorDebug(cordebug, pid);
-
-			/* There exists a structure CLR_ENGINE_METRICS within in coreclr.dll which is exported at ordinal 2. This structure indicates the RVA of the actual continue event that should be signalled
-			 * to indicate the CLR can continue starting. But how does the CLR know to wait on this event at all? In debugger.cpp!NotifyDebuggerOfStartup() it calls
-			 * OpenStartupNotificationEvent(). If that returns the event that was created by GetStartupNotificationEvent() then that event is set and closed,
-			 * and then g_hContinueStartupEvent is waited on infinitely. g_hContinueStartupEvent is one of the components that make up the CLR_ENGINE_METRICS g_CLREngineMetrics,
-			 * hence it all comes full circle. */
-			//NativeMethods.SetEvent(runtime.Handle);
-		}
-		finally
-		{
-			//CloseCLREnumeration does not call WakeRuntimes(), hence we MUST call SetEvent above.
-			//WakeRuntimes is called in InvokeStartupCallback() and UnregisterForRuntimeStartup() -> Unregister()
-			dbgshim.CloseCLREnumeration(enumResult);
-		}
-
-		//while (true) Thread.Sleep(1);
-	}
+	// public static ICorDebug Manual(int pid)
+	// {
+	// 	/* If the process initializes the CLR before GetStartupNotificationEvent is called (e.g. because you were playing in the debugger between launching
+	// 	 * the process and reaching this line of code) then WaitForSingleObject below will hang indefinitely. You can prevent this by starting the process suspended.
+	// 	 * This event is signalled by debugger.cpp!OpenStartupNotificationEvent() which is called by NotifyDebuggerOfStartup(). Immediately after the startup event
+	// 	 * is signalled, the CLR waits on g_hContinueStartupEvent which is one of the three components that comprise the global CLR_ENGINE_METRICS g_CLREngineMetrics! */
+	// 	var startupEvent = DbgShim.GetStartupNotificationEvent(pid);
+	//
+	// 	//The event WaitForSingleObject is waiting on won't occur unless the process is resumed
+	// 	//DbgShim.ResumeProcess(resumeHandle);
+	//
+	// 	// //As stated above, if you started the process suspended, you need to resume the process otherwise the CLR will never be loaded.
+	// 	// var waitResult = NativeMethods.WaitForSingleObject(startupEvent, -1);
+	// 	//
+	// 	// if (waitResult != 0)
+	// 	//     throw new InvalidOperationException($"Failed to get startup event. Is the target process a .NET Core application? Wait Result: {waitResult}");
+	//
+	// 	var enumResult = DbgShim.EnumerateCLRs(pid);
+	//
+	// 	try
+	// 	{
+	// 		var runtime = enumResult.Items.Single();
+	//
+	// 		//Version String is a comma delimited value containing dbiVersion, pidDebuggee, hmodTargetCLR
+	// 		var versionStr = DbgShim.CreateVersionStringFromModule(pid, runtime.Path);
+	//
+	// 		/* Cordb::CheckCompatibility seems to be the only place where our debugger version is actually used,
+	// 		 * and it says that if the version is 4, its major version 4. Version 4.5 is treated as an "unrecognized future version"
+	// 		 * and is assigned major version 5, which is wrong. Cordb::CheckCompatibility then calls CordbProcess::IsCompatibleWith
+	// 		 * which doesn't actually seem to do anything either, despite what all the docs in it would imply. */
+	// 		var cordebug = DbgShim.CreateDebuggingInterfaceFromVersionEx(CorDebugInterfaceVersion.CorDebugVersion_4_0, versionStr);
+	// 		return cordebug;
+	// 		//Initialize ICorDebug, setup our managed callback and attach to the existing process. We attach while the CLR is blocked waiting for the "continue" event to be called
+	// 		//InitCorDebug(cordebug, pid);
+	//
+	// 		/* There exists a structure CLR_ENGINE_METRICS within in coreclr.dll which is exported at ordinal 2. This structure indicates the RVA of the actual continue event that should be signalled
+	// 		 * to indicate the CLR can continue starting. But how does the CLR know to wait on this event at all? In debugger.cpp!NotifyDebuggerOfStartup() it calls
+	// 		 * OpenStartupNotificationEvent(). If that returns the event that was created by GetStartupNotificationEvent() then that event is set and closed,
+	// 		 * and then g_hContinueStartupEvent is waited on infinitely. g_hContinueStartupEvent is one of the components that make up the CLR_ENGINE_METRICS g_CLREngineMetrics,
+	// 		 * hence it all comes full circle. */
+	// 		//NativeMethods.SetEvent(runtime.Handle);
+	// 	}
+	// 	finally
+	// 	{
+	// 		//CloseCLREnumeration does not call WakeRuntimes(), hence we MUST call SetEvent above.
+	// 		//WakeRuntimes is called in InvokeStartupCallback() and UnregisterForRuntimeStartup() -> Unregister()
+	// 		DbgShim.CloseCLREnumeration(enumResult);
+	// 	}
+	//
+	// 	//while (true) Thread.Sleep(1);
+	// }
 
 	// For applications like godot, which start their own CLR, diagnostics IPC may not be available immediately.
 	// Retry until it succeeds.

--- a/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
+++ b/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
@@ -1,5 +1,5 @@
 using Ardalis.GuardClauses;
-using ClrDebug;
+using ICorDebugSharp;
 using Microsoft.Diagnostics.NETCore.Client;
 using SharpDbg.Infrastructure.Debugger.Models;
 

--- a/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
+++ b/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
@@ -23,11 +23,9 @@ public static class ClrDebugExtensions
 	public static ICorDebug Mobile(RemoteAttachInfo remoteAttachInfo)
 	{
 		ICorDebug corDebug = null!;
-		// Requires ClrDebug 0.4.0, which unfortunately introduced an unrelated bug
-		// Uncomment once a release is available including this fix: https://github.com/lordmilko/ClrDebug/issues/26
-		// var result = Extensions.TryRegisterForRuntimeStartupRemotePort(dbgShim,
+		// var result = DbgShim.RegisterForRuntimeStartupRemotePort(
 		// 	remoteAttachInfo.Address,
-		// 	remoteAttachInfo.Port,
+		// 	checked((uint)remoteAttachInfo.Port),
 		// 	remoteAttachInfo.Platform,
 		// 	remoteAttachInfo.IsServer,
 		// 	remoteAttachInfo.MscordbiPath,

--- a/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
+++ b/src/SharpDbg.Infrastructure/ClrDebugExtensions.cs
@@ -22,15 +22,14 @@ public static class ClrDebugExtensions
 
 	public static ICorDebug Mobile(RemoteAttachInfo remoteAttachInfo)
 	{
-		ICorDebug corDebug = null!;
-		// var result = DbgShim.RegisterForRuntimeStartupRemotePort(
-		// 	remoteAttachInfo.Address,
-		// 	checked((uint)remoteAttachInfo.Port),
-		// 	remoteAttachInfo.Platform,
-		// 	remoteAttachInfo.IsServer,
-		// 	remoteAttachInfo.MscordbiPath,
-		// 	remoteAttachInfo.AssembliesPath, out corDebug);
-		// result.ThrowOnNotOK();
+		var result = DbgShim.RegisterForRuntimeStartupRemotePort(
+			remoteAttachInfo.Address,
+			checked((uint)remoteAttachInfo.Port),
+			remoteAttachInfo.Platform,
+			remoteAttachInfo.IsServer,
+			remoteAttachInfo.MscordbiPath,
+			remoteAttachInfo.AssembliesPath, out var corDebug);
+		Marshal.ThrowExceptionForHR(result);
 
 		Guard.Against.Null(corDebug);
 		return corDebug;

--- a/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
@@ -99,7 +99,7 @@ public class AsyncStepper
 			Guard.Against.Null(function);
 
 			// Call builder.SetNotificationForWaitCompletion(true)
-			var typeParameterArgs = objectValue.ExactType.TypeParameters.Select(t => t.Raw).ToArray();
+			var typeParameterArgs = objectValue.ExactType.TypeParameters;
 			// result should be null, as SetNotificationForWaitCompletion returns void
 			var result = await eval.CallParameterizedFunctionAsync(
 				_managedCallback,
@@ -108,7 +108,7 @@ public class AsyncStepper
 				typeParameterArgs.Length,
 				typeParameterArgs,
 				2,
-				[builder.Raw, boolValue.Raw]
+				[builder, boolValue]
 			);
 			if (result is not null) throw new InvalidOperationException("SetNotificationForWaitCompletion returned a value when void was expected");
 			return true;
@@ -131,7 +131,7 @@ public class AsyncStepper
 			const string methodName = "NotifyDebuggerOfWaitCompletion";
 
 			// Find the module
-			CorDebugModule? targetModule = null;
+			ICorDebugModule? targetModule = null;
 			foreach (var module in _modules.Values)
 			{
 				if (module.Module.Name.EndsWith(assemblyName, StringComparison.OrdinalIgnoreCase))
@@ -506,7 +506,7 @@ public class AsyncStepper
 			if (fieldDef.IsNil)
 				return null;
 
-			var fieldValue = thisObjectValue.GetFieldValue(thisClass.Raw, fieldDef);
+			var fieldValue = thisObjectValue.GetFieldValue(thisClass, fieldDef);
 			var fieldValueUnwrapped = fieldValue.UnwrapDebugValue();
 			return fieldValueUnwrapped;
 		}
@@ -542,9 +542,9 @@ public class AsyncStepper
 			_debugger.EvalStatus,
 			getMethod,
 			builder.ExactType.TypeParameters.Length,
-			builder.ExactType.TypeParameters.Select(t => t.Raw).ToArray(),
+			builder.ExactType.TypeParameters,
 			1,
-			[builder.Raw]
+			[builder]
 		);
 
 		if (result is not ICorDebugHandleValue handleValue) throw new InvalidOperationException("ObjectIdForDebugger is not a handle value");
@@ -560,7 +560,7 @@ public class AsyncStepper
 		var moduleAddress = function.Module.BaseAddress;
 		var methodToken = function.Token;
 
-		return moduleAddress == asyncBp.ModuleAddress && methodToken == asyncBp.MethodToken && breakpoint.Raw == asyncBp.Breakpoint?.Raw;
+		return moduleAddress == asyncBp.ModuleAddress && methodToken == asyncBp.MethodToken && breakpoint == asyncBp.Breakpoint;
 	}
 
 	/// <summary>

--- a/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
@@ -24,7 +24,7 @@ public class AsyncStepper
 
 	private class AsyncBreakpoint
 	{
-		public CorDebugFunctionBreakpoint? Breakpoint;
+		public ICorDebugFunctionBreakpoint? Breakpoint;
 		public CORDB_ADDRESS ModuleAddress;
 		public mdMethodDef MethodToken;
 		public uint ILOffset;
@@ -54,7 +54,7 @@ public class AsyncStepper
 		public uint ResumeOffset;
 		public AsyncStepStatus Status;
 		public AsyncBreakpoint? Breakpoint;
-		public CorDebugHandleValue? AsyncIdHandle; // Strong handle to builder's ObjectIdForDebugger
+		public ICorDebugHandleValue? AsyncIdHandle; // Strong handle to builder's ObjectIdForDebugger
 
 		public void Dispose()
 		{
@@ -85,7 +85,7 @@ public class AsyncStepper
 	/// <summary>
 	/// Call SetNotificationForWaitCompletion on the async builder
 	/// </summary>
-	private async Task<bool> SetNotificationForWaitCompletion(CorDebugValue builder, CorDebugILFrame? frame, CorDebugThread thread)
+	private async Task<bool> SetNotificationForWaitCompletion(ICorDebugValue builder, ICorDebugILFrame? frame, ICorDebugThread thread)
 	{
 		try
 		{
@@ -122,7 +122,7 @@ public class AsyncStepper
 	/// <summary>
 	/// Setup breakpoint in Task.NotifyDebuggerOfWaitCompletion method
 	/// </summary>
-	private bool SetupNotifyDebuggerOfWaitCompletionBreakpoint(CorDebugThread thread)
+	private bool SetupNotifyDebuggerOfWaitCompletionBreakpoint(ICorDebugThread thread)
 	{
 		try
 		{
@@ -180,7 +180,7 @@ public class AsyncStepper
 	/// <param name="stepType">Type of step</param>
 	/// <param name="shouldUseSimpleStepper">Output: whether to use simple stepper</param>
 	/// <returns>True if async stepping was initiated, false otherwise</returns>
-	public async Task<(bool HandledByAsyncStepper, bool? ShouldUseSimpleStepper)> TrySetupAsyncStep(CorDebugThread thread, StepType stepType)
+	public async Task<(bool HandledByAsyncStepper, bool? ShouldUseSimpleStepper)> TrySetupAsyncStep(ICorDebugThread thread, StepType stepType)
 	{
 		try
 		{
@@ -188,7 +188,7 @@ public class AsyncStepper
 			if (frame is null) return (false, null);
 
 			var function = frame.Function;
-			var moduleAddress = (long)function.Module.BaseAddress;
+			var moduleAddress = function.Module.BaseAddress;
 			var methodToken = function.Token;
 			var ilCode = function.ILCode;
 			var methodVersion = ilCode.VersionNumber;
@@ -201,7 +201,7 @@ public class AsyncStepper
 			var asyncInfo = moduleInfo.SymbolReader.GetAsyncMethodSteppingInfo(methodToken);
 			if (asyncInfo is null) return (false, null);
 
-			var ilFrame = frame as CorDebugILFrame;
+			var ilFrame = frame as ICorDebugILFrame;
 
 			// Check if we're at the end of an async method and need step-out behavior
 			if (stepType != StepType.StepOut)
@@ -243,7 +243,7 @@ public class AsyncStepper
 						}
 
 						// Not async void - use NotifyDebuggerOfWaitCompletion magic
-						var success = await SetNotificationForWaitCompletion(builder, frame as CorDebugILFrame, thread);
+						var success = await SetNotificationForWaitCompletion(builder, frame as ICorDebugILFrame, thread);
 						if (success)
 						{
 							// Setup breakpoint in Task.NotifyDebuggerOfWaitCompletion
@@ -312,7 +312,7 @@ public class AsyncStepper
 	/// <param name="breakpoint">Breakpoint that was hit</param>
 	/// <param name="shouldStop">Output: whether execution should stop</param>
 	/// <returns>True if breakpoint was handled by async stepper</returns>
-	public async Task<(bool HandledByAsyncStepper, bool? ShouldStop)> TryHandleBreakpoint(CorDebugThread thread, CorDebugFunctionBreakpoint breakpoint)
+	public async Task<(bool HandledByAsyncStepper, bool? ShouldStop)> TryHandleBreakpoint(ICorDebugThread thread, ICorDebugFunctionBreakpoint breakpoint)
 	{
 		using (await _lock2.LockAsync())
 		{
@@ -342,7 +342,7 @@ public class AsyncStepper
 			}
 
 			// Check if IP matches expected offset
-			var frame = thread.ActiveFrame as CorDebugILFrame;
+			var frame = thread.ActiveFrame as ICorDebugILFrame;
 			if (frame is null)
 			{
 				_currentAsyncStep?.Dispose();
@@ -378,7 +378,7 @@ public class AsyncStepper
 		return (false, null);
 	}
 
-	private async Task<(bool HandledByAsyncStepper, bool? ShouldStop)> HandleYieldBreakpoint(CorDebugThread thread, CorDebugILFrame frame)
+	private async Task<(bool HandledByAsyncStepper, bool? ShouldStop)> HandleYieldBreakpoint(ICorDebugThread thread, ICorDebugILFrame frame)
 	{
 		// Disable all simple steppers when we hit the yield breakpoint
 		DisableAllSimpleSteppers(thread.Process);
@@ -411,7 +411,7 @@ public class AsyncStepper
 		return (true, false);
 	}
 
-	private async Task<(bool HandledByAsyncStepper, bool? ShouldStop)> HandleResumeBreakpoint(CorDebugThread thread)
+	private async Task<(bool HandledByAsyncStepper, bool? ShouldStop)> HandleResumeBreakpoint(ICorDebugThread thread)
 	{
 		// Check if this is the same thread
 		if (_currentAsyncStep!.ThreadId == thread.Id)
@@ -424,7 +424,7 @@ public class AsyncStepper
 		// Different thread - check async ID
 		else if (_currentAsyncStep!.AsyncIdHandle is not null)
 		{
-			var currentAsyncId = await GetAsyncIdReference((CorDebugILFrame)thread.ActiveFrame);
+			var currentAsyncId = await GetAsyncIdReference((ICorDebugILFrame)thread.ActiveFrame);
 			if (currentAsyncId is not null)
 			{
 				var currentAddress = currentAsyncId.Dereference().Address;
@@ -461,7 +461,7 @@ public class AsyncStepper
 		return null;
 	}
 
-	private async Task<CorDebugHandleValue?> GetAsyncIdReference(CorDebugILFrame frame)
+	private async Task<ICorDebugHandleValue?> GetAsyncIdReference(ICorDebugILFrame frame)
 	{
 		Guard.Against.Null(frame);
 		var builder = GetAsyncBuilder(frame);
@@ -471,7 +471,7 @@ public class AsyncStepper
 		return objectId;
 	}
 
-	private CorDebugValue? GetAsyncBuilder(CorDebugILFrame frame)
+	private ICorDebugValue? GetAsyncBuilder(ICorDebugILFrame frame)
 	{
 		try
 		{
@@ -516,7 +516,7 @@ public class AsyncStepper
 		}
 	}
 
-	private async Task<CorDebugHandleValue?> GetObjectIdForDebugger(CorDebugValue builder, CorDebugILFrame frame)
+	private async Task<ICorDebugHandleValue?> GetObjectIdForDebugger(ICorDebugValue builder, ICorDebugILFrame frame)
 	{
 
 		var objectValue = builder.UnwrapDebugValueToObject();
@@ -547,11 +547,11 @@ public class AsyncStepper
 			[builder.Raw]
 		);
 
-		if (result is not CorDebugHandleValue handleValue) throw new InvalidOperationException("ObjectIdForDebugger is not a handle value");
+		if (result is not ICorDebugHandleValue handleValue) throw new InvalidOperationException("ObjectIdForDebugger is not a handle value");
 		return handleValue;
 	}
 
-	private bool MatchesBreakpoint(CorDebugFunctionBreakpoint breakpoint, AsyncBreakpoint asyncBp, CorDebugThread thread)
+	private bool MatchesBreakpoint(ICorDebugFunctionBreakpoint breakpoint, AsyncBreakpoint asyncBp, ICorDebugThread thread)
 	{
 		var frame = thread.ActiveFrame;
 		if (frame is null) return false;
@@ -566,7 +566,7 @@ public class AsyncStepper
 	/// <summary>
 	/// Disable all simple steppers across all app domains
 	/// </summary>
-	private void DisableAllSimpleSteppers(CorDebugProcess process)
+	private void DisableAllSimpleSteppers(ICorDebugProcess process)
 	{
 		var appDomains = process.EnumerateAppDomains();
 		foreach (var appDomain in appDomains)

--- a/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
@@ -1,5 +1,5 @@
 using Ardalis.GuardClauses;
-using ClrDebug;
+using ICorDebugSharp;
 using NeoSmart.AsyncLock;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 

--- a/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
@@ -145,7 +145,7 @@ public class AsyncStepper
 				return false;
 
 			// TODO: This doesn't need to be looked up every time
-			var metadataImport = targetModule.GetMetaDataInterface().MetaDataImport;
+			var metadataImport = targetModule.GetMetaDataInterface<IMetaDataImport>();
 			var classDef = metadataImport.FindTypeDefByNameOrNull(className, mdToken.Nil);
 			if (classDef is null) return false;
 
@@ -478,7 +478,7 @@ public class AsyncStepper
 			var function = frame.Function;
 			var module = function.Module;
 			var methodToken = function.Token;
-			var metadataImport = module.GetMetaDataInterface().MetaDataImport;
+			var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 
 			var methodProps = metadataImport.GetMethodProps(methodToken);
 			var isStatic = (methodProps.pdwAttr & CorMethodAttr.mdStatic) != 0;
@@ -522,7 +522,7 @@ public class AsyncStepper
 		var objectValue = builder.UnwrapDebugValueToObject();
 		var @class = objectValue.Class;
 		var module = @class.Module;
-		var metadataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 
 		var propertyDef = metadataImport.GetPropertyWithName(@class.Token, "ObjectIdForDebugger");
 		if (propertyDef is null || propertyDef.Value.IsNil)

--- a/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/AsyncStepper.cs
@@ -492,12 +492,12 @@ public class AsyncStepper
 				return null;
 
 			var thisValue = arguments[0];
-			var thisRefValue = thisValue as CorDebugReferenceValue;
+			var thisRefValue = thisValue as ICorDebugReferenceValue;
 			if (thisRefValue is null || thisRefValue.IsNull)
 				return null;
 
 			var thisValueUnwrapped = thisRefValue.Dereference();
-			var thisObjectValue = thisValueUnwrapped as CorDebugObjectValue;
+			var thisObjectValue = thisValueUnwrapped as ICorDebugObjectValue;
 			if (thisObjectValue is null)
 				return null;
 

--- a/src/SharpDbg.Infrastructure/Debugger/BreakpointManager.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/BreakpointManager.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
 

--- a/src/SharpDbg.Infrastructure/Debugger/BreakpointManager.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/BreakpointManager.cs
@@ -21,7 +21,7 @@ public class BreakpointManager
 		public int EndLine { get; set; }
 		public int? EndColumn { get; set; }
 		public bool Verified { get; set; }
-		public CorDebugFunctionBreakpoint? CorBreakpoint { get; set; }
+		public ICorDebugFunctionBreakpoint? CorBreakpoint { get; set; }
 		public string? Message { get; set; }
 		public SymbolReader.ResolvedBreakpoint? ResolvedBreakpointFromPdb { get; set; }
 		public CORDB_ADDRESS? ModuleBaseAddress { get; set; }
@@ -121,7 +121,7 @@ public class BreakpointManager
 	{
 		lock (_lock)
 		{
-			return _breakpoints.Values.FirstOrDefault(bp => bp.CorBreakpoint?.Raw == corBreakpoint);
+			return _breakpoints.Values.FirstOrDefault(bp => bp.CorBreakpoint == corBreakpoint);
 		}
 	}
 

--- a/src/SharpDbg.Infrastructure/Debugger/CorDebugValueExtensions.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/CorDebugValueExtensions.cs
@@ -1,5 +1,5 @@
 using System.Runtime.InteropServices;
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
 

--- a/src/SharpDbg.Infrastructure/Debugger/CorDebugValueExtensions.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/CorDebugValueExtensions.cs
@@ -5,24 +5,24 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public static class CorDebugValueExtensions
 {
-	public static CorDebugObjectValue UnwrapDebugValueToObject(this CorDebugValue corDebugValue)
+	public static ICorDebugObjectValue UnwrapDebugValueToObject(this ICorDebugValue corDebugValue)
 	{
 		var unwrappedValue = corDebugValue.UnwrapDebugValue();
-		if (unwrappedValue is CorDebugObjectValue objectValue)
+		if (unwrappedValue is ICorDebugObjectValue objectValue)
 		{
 			return objectValue;
 		}
 		throw new InvalidOperationException("CorDebugValue is not an CorDebugObjectValue");
 	}
 
-	public static CorDebugValue UnwrapDebugValue(this CorDebugValue corDebugValue)
+	public static ICorDebugValue UnwrapDebugValue(this ICorDebugValue corDebugValue)
 	{
 		var valueToCheck = corDebugValue;
-		if (valueToCheck is CorDebugReferenceValue { IsNull: false } refValue)
+		if (valueToCheck is ICorDebugReferenceValue { IsNull: false } refValue)
 		{
 			valueToCheck = refValue.Dereference();
 		}
-		if (valueToCheck is CorDebugBoxValue boxValue)
+		if (valueToCheck is ICorDebugBoxValue boxValue)
 		{
 			valueToCheck = boxValue.Object;
 		}
@@ -30,30 +30,7 @@ public static class CorDebugValueExtensions
 		return valueToCheck;
 	}
 
-	/// <summary>
-	/// Use this until https://github.com/lordmilko/ClrDebug/pull/20 is resolved
-	/// </summary>
-	public static string GetStringWithoutBug(this CorDebugStringValue corDebugStringValue, int cchString)
-	{
-		TryGetString(corDebugStringValue, cchString, out var szStringResult).ThrowOnNotOK();
-		return szStringResult!;
-	}
-
-	private static HRESULT TryGetString(CorDebugStringValue corDebugStringValue, int cchString, out string? szStringResult)
-	{
-		char[] chArray = new char[cchString];
-		int pcchString;
-		int num = (int)corDebugStringValue.Raw.GetString(cchString, out pcchString, chArray);
-		if (num == 0)
-		{
-			szStringResult = ClrDebug.Extensions.CreateString(chArray, pcchString + 1);
-			return (HRESULT)num;
-		}
-		szStringResult = null;
-		return (HRESULT)num;
-	}
-
-	public static byte[] GetValueAsBytes(this CorDebugGenericValue corDebugGenericValue)
+	public static byte[] GetValueAsBytes(this ICorDebugGenericValue corDebugGenericValue)
 	{
 		IntPtr buffer = Marshal.AllocHGlobal(corDebugGenericValue.Size);
 		try
@@ -69,12 +46,12 @@ public static class CorDebugValueExtensions
 		}
 	}
 
-	public static CorDebugValue? GetClassFieldValue(this CorDebugObjectValue objectValue, CorDebugILFrame ilFrame, string fieldName)
+	public static ICorDebugValue? GetClassFieldValue(this ICorDebugObjectValue objectValue, ICorDebugILFrame ilFrame, string fieldName)
 	{
-		CorDebugType? currentType = objectValue.ExactType;
+		ICorDebugType? currentType = objectValue.ExactType;
 		mdFieldDef foundFieldDef = default;
-		CorDebugClass? foundClass = null;
-		MetaDataImport? foundMetadata = null;
+		ICorDebugClass? foundClass = null;
+		IMetaDataImport? foundMetadata = null;
 
 		// Find field on base type if necessary
 		while (currentType is not null)
@@ -96,30 +73,30 @@ public static class CorDebugValueExtensions
 
 		var isStatic = foundFieldDef.IsStatic(foundMetadata);
 		var isLiteral = foundFieldDef.IsLiteral(foundMetadata);
-		var fieldCorDebugValue = isLiteral ? foundFieldDef.GetLiteralCorDebugValue(foundMetadata, ilFrame) : isStatic ? foundClass.GetStaticFieldValue(foundFieldDef, ilFrame.Raw) : objectValue.GetFieldValue(foundClass.Raw, foundFieldDef);
+		var fieldCorDebugValue = isLiteral ? foundFieldDef.GetLiteralCorDebugValue(foundMetadata, ilFrame) : isStatic ? foundClass.GetStaticFieldValue(foundFieldDef, ilFrame) : objectValue.GetFieldValue(foundClass, foundFieldDef);
 		return fieldCorDebugValue;
 	}
 
-	public static CorDebugGenericValue GetLiteralCorDebugValue(this mdFieldDef fieldDef, MetaDataImport metadataImport, CorDebugILFrame ilFrame)
+	public static ICorDebugGenericValue GetLiteralCorDebugValue(this mdFieldDef fieldDef, IMetaDataImport metadataImport, ICorDebugILFrame ilFrame)
 	{
 		var fieldProps = metadataImport.GetFieldProps(fieldDef);
 		var ppValue = fieldProps.ppValue;
 		var corElementType = fieldProps.pdwCPlusTypeFlag;
 		var eval = ilFrame.Chain.Thread.CreateEval();
 		var createdValue = eval.CreateValue(corElementType, null);
-		if (createdValue is not CorDebugGenericValue corDebugGenericValue) throw new InvalidOperationException("Expected a CorDebugGenericValue for literal value");
+		if (createdValue is not ICorDebugGenericValue corDebugGenericValue) throw new InvalidOperationException("Expected a CorDebugGenericValue for literal value");
 		corDebugGenericValue.SetValue(ppValue);
 		return corDebugGenericValue;
 	}
 
-	public static async Task<CorDebugValue?> GetPropertyValue(this CorDebugValue objectValue, CorDebugManagedCallback callback, EvalStatus evalStatus, CorDebugILFrame ilFrame, string propertyName)
+	public static async Task<ICorDebugValue?> GetPropertyValue(this ICorDebugValue objectValue, CorDebugManagedCallback callback, EvalStatus evalStatus, ICorDebugILFrame ilFrame, string propertyName)
 	{
 		var unwrappedValue = objectValue.UnwrapDebugValueToObject();
 
-		CorDebugType? currentType = unwrappedValue.ExactType;
+		ICorDebugType? currentType = unwrappedValue.ExactType;
 		mdProperty foundPropertyDef = default;
-		CorDebugClass? foundClass = null;
-		MetaDataImport? foundMetadata = null;
+		ICorDebugClass? foundClass = null;
+		IMetaDataImport? foundMetadata = null;
 
 		// Find property on base type if necessary
 		while (currentType is not null)
@@ -157,21 +134,20 @@ public static class CorDebugValueExtensions
 		var parameterizedContainingType = objectValue.ExactType;
 
 		var typeParameterTypes = parameterizedContainingType.TypeParameters;
-		var typeParameterArgs = typeParameterTypes.Select(t => t.Raw).ToArray();
 
 		// For instance properties, pass the object; for static, pass nothing. Must pass the original CorDebugReferenceValue, not the dereferenced one.
-		ICorDebugValue[] corDebugValues = isStatic ? [] : [objectValue!.Raw];
+		ICorDebugValue[] corDebugValues = isStatic ? [] : [objectValue];
 
-		var returnValue = await eval.CallParameterizedFunctionAsync(callback, evalStatus, getMethod, typeParameterTypes.Length, typeParameterArgs, corDebugValues.Length, corDebugValues);
+		var returnValue = await eval.CallParameterizedFunctionAsync(callback, evalStatus, getMethod, typeParameterTypes.Length, typeParameterTypes, corDebugValues.Length, corDebugValues);
 		return returnValue;
 	}
 
-	public static CorDebugFunction? GetPropertySetter(this CorDebugObjectValue objectValue, string propertyName)
+	public static ICorDebugFunction? GetPropertySetter(this ICorDebugObjectValue objectValue, string propertyName)
 	{
 		return null;
 	}
 
-	public static bool IsExceptionType(this CorDebugType corDebugType)
+	public static bool IsExceptionType(this ICorDebugType corDebugType)
 	{
 		var type = corDebugType;
 		while (type is not null)

--- a/src/SharpDbg.Infrastructure/Debugger/CorDebugValueExtensions.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/CorDebugValueExtensions.cs
@@ -80,7 +80,7 @@ public static class CorDebugValueExtensions
 		while (currentType is not null)
 		{
 			var cls = currentType.Class;
-			var meta = cls.Module.GetMetaDataInterface().MetaDataImport;
+			var meta = cls.Module.GetMetaDataInterface<IMetaDataImport>();
 			var field = meta.EnumFieldsWithName(cls.Token, fieldName).SingleOrDefault();
 			if (field.IsNil is false)
 			{
@@ -125,7 +125,7 @@ public static class CorDebugValueExtensions
 		while (currentType is not null)
 		{
 			var cls = currentType.Class;
-			var meta = cls.Module.GetMetaDataInterface().MetaDataImport;
+			var meta = cls.Module.GetMetaDataInterface<IMetaDataImport>();
 			var prop = meta.GetPropertyWithName(cls.Token, propertyName);
 			if (prop?.IsNil is false)
 			{

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/CompiledExpressionEvaluationContext.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/CompiledExpressionEvaluationContext.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/CompiledExpressionEvaluationContext.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/CompiledExpressionEvaluationContext.cs
@@ -2,18 +2,18 @@ using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator;
 
-public class CompiledExpressionEvaluationContext(CorDebugThread thread, ThreadId threadId, FrameStackDepth stackDepth, CorDebugValue? rootValue = null)
+public class CompiledExpressionEvaluationContext(ICorDebugThread thread, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue? rootValue = null)
 {
-	public CorDebugThread Thread { get; set; } = thread;
+	public ICorDebugThread Thread { get; set; } = thread;
 	public FrameStackDepth StackDepth { get; set; } = stackDepth;
 	public ThreadId ThreadId { get; set; } = threadId;
 	/// Used as the root value for identifier resolution, if provided. Primarily for evaluating DebuggerDisplay expressions, which only have access to the current object.
-	public CorDebugValue? RootValue { get; set; } = rootValue;
+	public ICorDebugValue? RootValue { get; set; } = rootValue;
 }
 
-public class RuntimeAssemblyPrimitiveTypeClasses(Dictionary<CorElementType, CorDebugClass> corElementToValueClassMap, CorDebugClass? corVoidClass, CorDebugClass? corDecimalClass)
+public class RuntimeAssemblyPrimitiveTypeClasses(Dictionary<CorElementType, ICorDebugClass> corElementToValueClassMap, ICorDebugClass? corVoidClass, ICorDebugClass? corDecimalClass)
 {
-	public Dictionary<CorElementType, CorDebugClass> CorElementToValueClassMap { get; } = corElementToValueClassMap;
-	public CorDebugClass? CorVoidClass { get; } = corVoidClass;
-	public CorDebugClass? CorDecimalClass { get; } = corDecimalClass;
+	public Dictionary<CorElementType, ICorDebugClass> CorElementToValueClassMap { get; } = corElementToValueClassMap;
+	public ICorDebugClass? CorVoidClass { get; } = corVoidClass;
+	public ICorDebugClass? CorDecimalClass { get; } = corDecimalClass;
 }

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using ClrDebug;
+using ICorDebugSharp;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Compiler;
 
 namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter.cs
@@ -129,7 +129,7 @@ public partial class CompiledExpressionInterpreter(RuntimeAssemblyPrimitiveTypeC
 
 public class EvaluationResult
 {
-	public CorDebugValue? Value { get; set; }
+	public ICorDebugValue? Value { get; set; }
 	public bool Editable { get; set; }
 	public SetterData? SetterData { get; set; }
 	public string? Error { get; set; }

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
@@ -25,14 +25,14 @@ public partial class CompiledExpressionInterpreter
 		var argCount = command.Arguments[1] as int? ?? 0;
 		var name = command.Arguments[0] as string ?? "";
 
-		var genericTypes = new List<CorDebugType?>();
+		var genericTypes = new List<ICorDebugType?>();
 		var generics = new StringBuilder(">");
 		genericTypes.Capacity = argCount;
 
 		for (int i = 0; i < argCount; i++)
 		{
 			var value = await GetFrontStackEntryValue(evalStack);
-			CorDebugType? type = value?.ExactType;
+			ICorDebugType? type = value?.ExactType;
 
 			generics.Insert(0, "," + type?.GetType().Name ?? "");
 			genericTypes.Add(type);
@@ -57,7 +57,7 @@ public partial class CompiledExpressionInterpreter
 		if (argCount < 0)
 			throw new ArgumentException("Invalid argument count");
 
-		var args = new CorDebugValue[argCount];
+		var args = new ICorDebugValue[argCount];
 		for (var i = argCount - 1; i >= 0; i--)
 		{
 			args[i] = await GetFrontStackEntryValue(evalStack);
@@ -82,8 +82,8 @@ public partial class CompiledExpressionInterpreter
 		bool idsEmpty = false;
 		bool isInstance = true;
 
-		CorDebugValue? objValue;
-		CorDebugType? objType;
+		ICorDebugValue? objValue;
+		ICorDebugType? objType;
 
 		if (entry.CorDebugValue is null && entry.Identifiers.Count == 0)
 		{
@@ -123,7 +123,7 @@ public partial class CompiledExpressionInterpreter
 			if (_runtimeAssemblyPrimitiveTypeClasses.CorElementToValueClassMap.TryGetValue(elemType, out var boxedClass))
 			{
 				var size = objValue.Size;
-				var data = objValue.UnwrapDebugValue() is CorDebugGenericValue genValue
+				var data = objValue.UnwrapDebugValue() is ICorDebugGenericValue genValue
 					? genValue.GetValueAsBytes()
 					: null;
 
@@ -142,7 +142,7 @@ public partial class CompiledExpressionInterpreter
 
 		if (objType is null && objValue is null) throw new InvalidOperationException("Could not resolve target type for method invocation");
 
-		CorDebugFunction? function = null;
+		ICorDebugFunction? function = null;
 		bool? searchStatic = objType is null;
 
 		if (objType is not null)
@@ -165,12 +165,12 @@ public partial class CompiledExpressionInterpreter
 
 		if (isInstance)
 		{
-			valueArgs.Add(objValue!.Raw);
+			valueArgs.Add(objValue);
 		}
 
 		foreach (var arg in args)
 		{
-			valueArgs.Add(arg!.Raw);
+			valueArgs.Add(arg);
 		}
 
 		if (objType is not null)
@@ -188,7 +188,7 @@ public partial class CompiledExpressionInterpreter
 			{
 				if (entry.GenericTypeCache[i] is not null)
 				{
-					typeArgs.Add(entry.GenericTypeCache[i]!.Raw);
+					typeArgs.Add(entry.GenericTypeCache[i]);
 				}
 			}
 		}
@@ -215,10 +215,10 @@ public partial class CompiledExpressionInterpreter
 	}
 
 	// TODO: Refactor - this doesn't belong in this class
-	public static CorDebugFunction? FindMethodOnType(
-		CorDebugType type,
+	public static ICorDebugFunction? FindMethodOnType(
+		ICorDebugType type,
 		string methodName,
-		CorDebugValue[] args,
+		ICorDebugValue[] args,
 		bool searchStatic,
 		bool idsEmpty)
 	{
@@ -256,7 +256,7 @@ public partial class CompiledExpressionInterpreter
 		return null;
 	}
 
-	private static bool IsMethodParameterMatch(CorDebugFunction method, CorDebugValue[] args)
+	private static bool IsMethodParameterMatch(ICorDebugFunction method, ICorDebugValue[] args)
 	{
 		var metaDataImport = method.Class.Module.GetMetaDataInterface<IMetaDataImport>();
 
@@ -384,7 +384,7 @@ public partial class CompiledExpressionInterpreter
 
 		var stringBuilder = new StringBuilder();
 
-		var components = new CorDebugValue[componentCount];
+		var components = new ICorDebugValue[componentCount];
 		// Retrieve components in reverse order
 		for (var i = componentCount - 1; i >= 0; i--)
 		{
@@ -395,13 +395,13 @@ public partial class CompiledExpressionInterpreter
 		foreach (var value in components)
 		{
 			var unwrapped = value.UnwrapDebugValue();
-			if (unwrapped is null || unwrapped is CorDebugReferenceValue { IsNull: true })
+			if (unwrapped is null || unwrapped is ICorDebugReferenceValue { IsNull: true })
 			{
 				stringBuilder.Append("null");
 			}
-			else if (unwrapped is CorDebugStringValue stringValue)
+			else if (unwrapped is ICorDebugStringValue stringValue)
 			{
-				stringBuilder.Append(stringValue.GetStringWithoutBug(stringValue.Length + 1));
+				stringBuilder.Append(stringValue.String);
 			}
 			else
 			{
@@ -417,12 +417,12 @@ public partial class CompiledExpressionInterpreter
 		});
 	}
 
-	private async Task<string> GetToStringResult(CorDebugValue value)
+	private async Task<string> GetToStringResult(ICorDebugValue value)
 	{
 		var unwrappedValue = value.UnwrapDebugValue();
 		if (_runtimeAssemblyPrimitiveTypeClasses.CorElementToValueClassMap.TryGetValue(unwrappedValue.Type, out var boxedClass))
 		{
-			var data = unwrappedValue is CorDebugGenericValue genValue
+			var data = unwrappedValue is ICorDebugGenericValue genValue
 				? genValue.GetValueAsBytes()
 				: null;
 
@@ -436,7 +436,7 @@ public partial class CompiledExpressionInterpreter
 		var eval = _context.Thread.CreateEval();
 		var result = await eval.CallParameterlessInstanceMethodAsync(_debuggerManagedCallback, _debugger.EvalStatus, corDebugFunction, value);
 		var unwrappedResult = result!.UnwrapDebugValue();
-		if (unwrappedResult is not CorDebugStringValue stringValue) throw new InvalidOperationException("ToString did not return a string");
+		if (unwrappedResult is not ICorDebugStringValue stringValue) throw new InvalidOperationException("ToString did not return a string");
 
 		var stringResult = stringValue.GetStringWithoutBug(stringValue.Length + 1);
 		return stringResult;
@@ -450,7 +450,7 @@ public partial class CompiledExpressionInterpreter
 		evalStack.AddFirst(new EvalStackEntry
 		{
 			Literal = true,
-			CorDebugValue = await CreatePrimitiveValue(CorElementType.Char, data)
+			CorDebugValue = await CreatePrimitiveValue(CorElementType.CHAR, data)
 		});
 	}
 
@@ -460,28 +460,28 @@ public partial class CompiledExpressionInterpreter
 
 		var elemType = typeArg switch
 		{
-			ePredefinedType.BoolKeyword => CorElementType.Boolean,
+			ePredefinedType.BoolKeyword => CorElementType.BOOLEAN,
 			ePredefinedType.ByteKeyword => CorElementType.U1,
-			ePredefinedType.CharKeyword => CorElementType.Char,
+			ePredefinedType.CharKeyword => CorElementType.CHAR,
 			ePredefinedType.DoubleKeyword => CorElementType.R8,
 			ePredefinedType.FloatKeyword => CorElementType.R4,
 			ePredefinedType.IntKeyword => CorElementType.I4,
 			ePredefinedType.LongKeyword => CorElementType.I8,
 			ePredefinedType.SByteKeyword => CorElementType.I1,
 			ePredefinedType.ShortKeyword => CorElementType.I2,
-			ePredefinedType.StringKeyword => CorElementType.String,
+			ePredefinedType.StringKeyword => CorElementType.STRING,
 			ePredefinedType.UShortKeyword => CorElementType.U2,
 			ePredefinedType.UIntKeyword => CorElementType.U4,
 			ePredefinedType.ULongKeyword => CorElementType.U8,
-			ePredefinedType.DecimalKeyword => CorElementType.ValueType,
+			ePredefinedType.DecimalKeyword => CorElementType.VALUETYPE,
 			_ => throw new ArgumentException($"Unsupported predefined type: {typeArg}")
 		};
 
 		evalStack.AddFirst(new EvalStackEntry
 		{
-			CorDebugValue = elemType == CorElementType.ValueType && typeArg == ePredefinedType.DecimalKeyword
+			CorDebugValue = elemType == CorElementType.VALUETYPE && typeArg == ePredefinedType.DecimalKeyword
 				? await CreateValueType(_runtimeAssemblyPrimitiveTypeClasses.CorDecimalClass!, null)
-				: elemType == CorElementType.String
+				: elemType == CorElementType.STRING
 					? await CreateString("")
 					: await CreatePrimitiveValue(elemType, null)
 		});
@@ -526,7 +526,7 @@ public partial class CompiledExpressionInterpreter
 		entry.CorDebugValue = value;
 		entry.Identifiers.Clear();
 
-		if (value is CorDebugReferenceValue refValue && !refValue.IsNull)
+		if (value is ICorDebugReferenceValue refValue && !refValue.IsNull)
 		{
 			entry.Identifiers.Add(identifier);
 		}
@@ -544,7 +544,7 @@ public partial class CompiledExpressionInterpreter
 		if (entry.CorDebugValue is not null)
 		{
 			var elemType = entry.CorDebugValue.Type;
-			if (elemType == CorElementType.Class)
+			if (elemType == CorElementType.CLASS)
 			{
 				var unwrapped = entry.CorDebugValue.UnwrapDebugValue();
 				size = unwrapped.Size;
@@ -577,7 +577,7 @@ public partial class CompiledExpressionInterpreter
 		var unwrappedLhs = lhsValue.UnwrapDebugValue();
 		var unwrappedRhs = rhsValue.UnwrapDebugValue();
 
-		if (unwrappedLhs is CorDebugGenericValue lhsGeneric && unwrappedRhs is CorDebugGenericValue rhsGeneric)
+		if (unwrappedLhs is ICorDebugGenericValue lhsGeneric && unwrappedRhs is ICorDebugGenericValue rhsGeneric)
 		{
 			// Primitive / value type assignment: copy raw bytes from RHS into LHS
 			var data = rhsGeneric.GetValueAsBytes();
@@ -589,7 +589,7 @@ public partial class CompiledExpressionInterpreter
 				}
 			}
 		}
-		else if (lhsValue is CorDebugReferenceValue lhsRef && rhsValue is CorDebugReferenceValue rhsRef)
+		else if (lhsValue is ICorDebugReferenceValue lhsRef && rhsValue is ICorDebugReferenceValue rhsRef)
 		{
 			// Reference type assignment: point LHS reference at the same object as RHS
 			lhsRef.Value = rhsRef.Value;
@@ -597,8 +597,8 @@ public partial class CompiledExpressionInterpreter
 		else if (unwrappedLhs.Raw is ICorDebugGenericValue && unwrappedRhs.Raw is ICorDebugGenericValue)
 		{
 			// CorDebugObjectValue also implements CorDebugGenericValue, cast it
-			var lhsAsGeneric = unwrappedLhs.As<CorDebugGenericValue>();
-			var rhsAsGeneric = unwrappedRhs.As<CorDebugGenericValue>();
+			var lhsAsGeneric = unwrappedLhs.As<ICorDebugGenericValue>();
+			var rhsAsGeneric = unwrappedRhs.As<ICorDebugGenericValue>();
 			var data = rhsAsGeneric.GetValueAsBytes();
 			unsafe { fixed (byte* p = data) { lhsAsGeneric.SetValue((IntPtr)p); } }
 		}
@@ -629,7 +629,7 @@ public partial class CompiledExpressionInterpreter
 		if ((rightType == CorElementType.String && leftType == CorElementType.String) ||
 			(rightType == CorElementType.Class && leftType == CorElementType.Class))
 		{
-			if (leftValue is CorDebugReferenceValue refValue && refValue.IsNull)
+			if (leftValue is ICorDebugReferenceValue refValue && refValue.IsNull)
 			{
 				evalStack.RemoveFirst();
 				evalStack.AddFirst(rightEntry);

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using ClrDebug;
+using ICorDebugSharp;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Compiler;
 
 namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
@@ -302,7 +302,7 @@ public partial class CompiledExpressionInterpreter
 		var realValue = await GetRealValueWithType(objValue!);
 		var elemType = realValue.Type;
 
-		if (elemType == CorElementType.SZArray || elemType == CorElementType.Array)
+		if (elemType == CorElementType.SZARRAY || elemType == CorElementType.ARRAY)
 		{
 			throw new NotImplementedException("Array element access not yet fully implemented");
 		}
@@ -329,8 +329,8 @@ public partial class CompiledExpressionInterpreter
 			ePredefinedType.UShortKeyword => CorElementType.U2,
 			ePredefinedType.SByteKeyword => CorElementType.I1,
 			ePredefinedType.ByteKeyword => CorElementType.U1,
-			ePredefinedType.CharKeyword => CorElementType.Char,
-			ePredefinedType.DecimalKeyword => CorElementType.ValueType,
+			ePredefinedType.CharKeyword => CorElementType.CHAR,
+			ePredefinedType.DecimalKeyword => CorElementType.VALUETYPE,
 			_ => throw new ArgumentException($"Unsupported numeric literal type: {typeArg}")
 		};
 
@@ -357,7 +357,7 @@ public partial class CompiledExpressionInterpreter
 		evalStack.AddFirst(new EvalStackEntry
 		{
 			Literal = true,
-			CorDebugValue = elemType == CorElementType.ValueType && typeArg == ePredefinedType.DecimalKeyword
+			CorDebugValue = elemType == CorElementType.VALUETYPE && typeArg == ePredefinedType.DecimalKeyword
 				? await CreateValueType(_runtimeAssemblyPrimitiveTypeClasses.CorDecimalClass!, data)
 				: await CreatePrimitiveValue(elemType, data)
 		});
@@ -438,7 +438,7 @@ public partial class CompiledExpressionInterpreter
 		var unwrappedResult = result!.UnwrapDebugValue();
 		if (unwrappedResult is not ICorDebugStringValue stringValue) throw new InvalidOperationException("ToString did not return a string");
 
-		var stringResult = stringValue.GetStringWithoutBug(stringValue.Length + 1);
+		var stringResult = stringValue.String;
 		return stringResult;
 	}
 

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
@@ -618,8 +618,8 @@ public partial class CompiledExpressionInterpreter
 		var rightType = realRight.Type;
 		var leftType = realLeft.Type;
 
-		if ((rightType == CorElementType.String && leftType == CorElementType.String) ||
-			(rightType == CorElementType.Class && leftType == CorElementType.Class))
+		if ((rightType == CorElementType.STRING && leftType == CorElementType.STRING) ||
+			(rightType == CorElementType.CLASS && leftType == CorElementType.CLASS))
 		{
 			if (leftValue is ICorDebugReferenceValue refValue && refValue.IsNull)
 			{

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
@@ -178,7 +178,7 @@ public partial class CompiledExpressionInterpreter
 			var typeParamsEnum = objType.EnumerateTypeParameters();
 			foreach (var typeParam in typeParamsEnum)
 			{
-				typeArgs.Add(typeParam.Raw);
+				typeArgs.Add(typeParam);
 			}
 		}
 
@@ -593,14 +593,6 @@ public partial class CompiledExpressionInterpreter
 		{
 			// Reference type assignment: point LHS reference at the same object as RHS
 			lhsRef.Value = rhsRef.Value;
-		}
-		else if (unwrappedLhs.Raw is ICorDebugGenericValue && unwrappedRhs.Raw is ICorDebugGenericValue)
-		{
-			// CorDebugObjectValue also implements CorDebugGenericValue, cast it
-			var lhsAsGeneric = unwrappedLhs.As<ICorDebugGenericValue>();
-			var rhsAsGeneric = unwrappedRhs.As<ICorDebugGenericValue>();
-			var data = rhsAsGeneric.GetValueAsBytes();
-			unsafe { fixed (byte* p = data) { lhsAsGeneric.SetValue((IntPtr)p); } }
 		}
 		else
 		{

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_Commands.cs
@@ -105,7 +105,7 @@ public partial class CompiledExpressionInterpreter
 				var ilFrame = _debugger.GetFrameForThreadIdAndStackDepth(_context.ThreadId, _context.StackDepth);
 				var corDebugFunction = ilFrame.Function;
 				var module = corDebugFunction.Class.Module;
-				var metaDataImport = module.GetMetaDataInterface().MetaDataImport;
+				var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
 				var methodProps = metaDataImport!.GetMethodProps(corDebugFunction.Token);
 				var declaringTypeDef = methodProps.pClass;
 				var typeProps = metaDataImport!.GetTypeDefProps(declaringTypeDef);
@@ -155,7 +155,7 @@ public partial class CompiledExpressionInterpreter
 			throw new InvalidOperationException($"Method '{methodName}' with {args.Length} parameters not found");
 		}
 
-		var methodProps2 = function.Class.Module.GetMetaDataInterface().MetaDataImport!.GetMethodProps(function.Token);
+		var methodProps2 = function.Class.Module.GetMetaDataInterface<IMetaDataImport>()!.GetMethodProps(function.Token);
 		isInstance = methodProps2.pdwAttr.IsMdStatic() is false;
 
 		var typeArgsCount = entry.GenericTypeCache?.Count ?? 0;
@@ -224,7 +224,7 @@ public partial class CompiledExpressionInterpreter
 	{
 		var typeClass = type.Class;
 		var module = typeClass.Module;
-		var metaDataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		var classToken = typeClass.Token;
 
 		var methods = metaDataImport!.EnumMethods(classToken);
@@ -258,7 +258,7 @@ public partial class CompiledExpressionInterpreter
 
 	private static bool IsMethodParameterMatch(CorDebugFunction method, CorDebugValue[] args)
 	{
-		var metaDataImport = method.Class.Module.GetMetaDataInterface().MetaDataImport;
+		var metaDataImport = method.Class.Module.GetMetaDataInterface<IMetaDataImport>();
 
 		// Get the method signature blob
 		var methodProps = metaDataImport.GetMethodProps(method.Token);

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_EvalStack.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_EvalStack.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_EvalStack.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_EvalStack.cs
@@ -4,13 +4,13 @@ namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 
 public partial class CompiledExpressionInterpreter
 {
-	private async Task<CorDebugValue> GetFrontStackEntryValue(LinkedList<EvalStackEntry> evalStack, bool needSetterData = false)
+	private async Task<ICorDebugValue> GetFrontStackEntryValue(LinkedList<EvalStackEntry> evalStack, bool needSetterData = false)
 	{
 		if (evalStack.First is null) throw new InvalidOperationException("Evaluation stack is empty");
 
 		var entry = evalStack.First.Value;
 		SetterData? setterData = needSetterData ? entry.SetterData : null;
-		CorDebugValue? optionalRootValue = null;
+		ICorDebugValue? optionalRootValue = null;
 		if (_context.RootValue is not null && entry.CorDebugValue is null)
 		{
 			if (entry.CorDebugValue is not null) throw new InvalidOperationException("Both root value and entry value are set");
@@ -23,7 +23,7 @@ public partial class CompiledExpressionInterpreter
 		return await _debugger.ResolveIdentifiers(entry.Identifiers, _context.ThreadId, _context.StackDepth, entry.CorDebugValue, optionalRootValue);
 	}
 
-	private async Task<CorDebugType?> GetFrontStackEntryType(LinkedList<EvalStackEntry> evalStack)
+	private async Task<ICorDebugType?> GetFrontStackEntryType(LinkedList<EvalStackEntry> evalStack)
 	{
 		if (evalStack.First is null)
 			return null;
@@ -36,8 +36,8 @@ public partial class CompiledExpressionInterpreter
 		);
 	}
 
-	private async Task<CorDebugType?> ResolveIdentifiersForType(
-		CorDebugValue? baseValue,
+	private async Task<ICorDebugType?> ResolveIdentifiersForType(
+		ICorDebugValue? baseValue,
 		List<string> identifiers)
 	{
 		// TODO: implement type resolution?
@@ -53,7 +53,7 @@ public partial class CompiledExpressionInterpreter
 		throw new ArgumentException($"The type or namespace name '{typeName}' couldn't be found");
 	}
 
-	private async Task<CorDebugValue> GetRealValueWithType(CorDebugValue value)
+	private async Task<ICorDebugValue> GetRealValueWithType(ICorDebugValue value)
 	{
 		var realValue = value.UnwrapDebugValue();
 		var elemType = realValue.Type;
@@ -66,7 +66,7 @@ public partial class CompiledExpressionInterpreter
 		return realValue;
 	}
 
-	private async Task<uint> GetElementIndex(CorDebugValue indexValue)
+	private async Task<uint> GetElementIndex(ICorDebugValue indexValue)
 	{
 		var unwrapped = indexValue.UnwrapDebugValue();
 
@@ -98,7 +98,7 @@ public partial class CompiledExpressionInterpreter
 		};
 	}
 
-	private async Task<(byte[] Value, CorElementType Type)> GetOperandDataTypeByValue(CorDebugValue value)
+	private async Task<(byte[] Value, CorElementType Type)> GetOperandDataTypeByValue(ICorDebugValue value)
 	{
 		var unwrapped = value.UnwrapDebugValue();
 		var elemType = unwrapped.Type;

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_EvalStack.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_EvalStack.cs
@@ -58,7 +58,7 @@ public partial class CompiledExpressionInterpreter
 		var realValue = value.UnwrapDebugValue();
 		var elemType = realValue.Type;
 
-		if (elemType == CorElementType.String || elemType == CorElementType.Class)
+		if (elemType == CorElementType.STRING || elemType == CorElementType.CLASS)
 		{
 			return value;
 		}
@@ -70,12 +70,12 @@ public partial class CompiledExpressionInterpreter
 	{
 		var unwrapped = indexValue.UnwrapDebugValue();
 
-		if (unwrapped is CorDebugReferenceValue refValue && refValue.IsNull)
+		if (unwrapped is ICorDebugReferenceValue refValue && refValue.IsNull)
 		{
 			throw new ArgumentException("Index cannot be null");
 		}
 
-		if (unwrapped is not CorDebugGenericValue genValue)
+		if (unwrapped is not ICorDebugGenericValue genValue)
 		{
 			throw new ArgumentException("Index must be an integer type");
 		}
@@ -109,7 +109,7 @@ public partial class CompiledExpressionInterpreter
 		// 	return (value, elemType);
 		// }
 
-		if (unwrapped is not CorDebugGenericValue genValue)
+		if (unwrapped is not ICorDebugGenericValue genValue)
 		{
 			throw new ArgumentException("Value is not a primitive type");
 		}

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_MethodSignature.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_MethodSignature.cs
@@ -153,9 +153,9 @@ public partial class CompiledExpressionInterpreter
 	{
 		return typeCode switch
 		{
-			SignatureTypeCode.Void => CorElementType.Void,
-			SignatureTypeCode.Boolean => CorElementType.Boolean,
-			SignatureTypeCode.Char => CorElementType.Char,
+			SignatureTypeCode.Void => CorElementType.VOID,
+			SignatureTypeCode.Boolean => CorElementType.BOOLEAN,
+			SignatureTypeCode.Char => CorElementType.CHAR,
 			SignatureTypeCode.SByte => CorElementType.I1,
 			SignatureTypeCode.Byte => CorElementType.U1,
 			SignatureTypeCode.Int16 => CorElementType.I2,
@@ -166,13 +166,13 @@ public partial class CompiledExpressionInterpreter
 			SignatureTypeCode.UInt64 => CorElementType.U8,
 			SignatureTypeCode.Single => CorElementType.R4,
 			SignatureTypeCode.Double => CorElementType.R8,
-			SignatureTypeCode.String => CorElementType.String,
-			SignatureTypeCode.Pointer => CorElementType.Ptr,
-			SignatureTypeCode.ByReference => CorElementType.ByRef,
-			SignatureTypeCode.TypeHandle => CorElementType.Class, // or ValueType
-			SignatureTypeCode.Object => CorElementType.Object,
-			SignatureTypeCode.SZArray => CorElementType.SZArray,
-			SignatureTypeCode.Array => CorElementType.Array,
+			SignatureTypeCode.String => CorElementType.STRING,
+			SignatureTypeCode.Pointer => CorElementType.PTR,
+			SignatureTypeCode.ByReference => CorElementType.BYREF,
+			SignatureTypeCode.TypeHandle => CorElementType.CLASS, // or ValueType
+			SignatureTypeCode.Object => CorElementType.OBJECT,
+			SignatureTypeCode.SZArray => CorElementType.SZARRAY,
+			SignatureTypeCode.Array => CorElementType.ARRAY,
 			SignatureTypeCode.IntPtr => CorElementType.I,
 			SignatureTypeCode.UIntPtr => CorElementType.U,
 			SignatureTypeCode.GenericTypeInstance => CorElementType.GenericInst,

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_MethodSignature.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_MethodSignature.cs
@@ -124,7 +124,7 @@ public partial class CompiledExpressionInterpreter
 		return typeInfo;
 	}
 
-	private static bool IsTypeMatch(TypeInfo paramType, CorElementType argType, CorDebugValue argValue)
+	private static bool IsTypeMatch(TypeInfo paramType, CorElementType argType, ICorDebugValue argValue)
 	{
 		// Map SignatureTypeCode to CorElementType for comparison
 		var expectedCorType = SignatureTypeCodeToCorElementType(paramType.TypeCode);
@@ -175,10 +175,10 @@ public partial class CompiledExpressionInterpreter
 			SignatureTypeCode.Array => CorElementType.ARRAY,
 			SignatureTypeCode.IntPtr => CorElementType.I,
 			SignatureTypeCode.UIntPtr => CorElementType.U,
-			SignatureTypeCode.GenericTypeInstance => CorElementType.GenericInst,
-			SignatureTypeCode.GenericTypeParameter => CorElementType.Var,
-			SignatureTypeCode.GenericMethodParameter => CorElementType.MVar,
-			_ => CorElementType.End
+			SignatureTypeCode.GenericTypeInstance => CorElementType.GENERICINST,
+			SignatureTypeCode.GenericTypeParameter => CorElementType.VAR,
+			SignatureTypeCode.GenericMethodParameter => CorElementType.MVAR,
+			_ => CorElementType.END
 		};
 	}
 }

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_MethodSignature.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_MethodSignature.cs
@@ -1,5 +1,5 @@
 using System.Reflection.Metadata;
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
@@ -25,7 +25,7 @@ public partial class CompiledExpressionInterpreter
 		};
 	}
 
-	private async Task<CorDebugValue> CalculateTwoOperands(
+	private async Task<ICorDebugValue> CalculateTwoOperands(
 		OperationType opType,
 		LinkedList<EvalStackEntry> evalStack)
 	{
@@ -75,7 +75,7 @@ public partial class CompiledExpressionInterpreter
 		return await CalculatePrimitiveOperands(opType, realValue1, realValue2, evalStack);
 	}
 
-	private async Task<CorDebugValue> CalculateOneOperand(
+	private async Task<ICorDebugValue> CalculateOneOperand(
 		OperationType opType,
 		LinkedList<EvalStackEntry> evalStack)
 	{
@@ -102,7 +102,7 @@ public partial class CompiledExpressionInterpreter
 		return await CalculatePrimitiveOperand(opType, realValue, evalStack);
 	}
 
-	private async Task<CorDebugValue> CalculatePrimitiveOperands(
+	private async Task<ICorDebugValue> CalculatePrimitiveOperands(
 		OperationType opType,
 		CorDebugValue value1,
 		CorDebugValue value2,
@@ -118,7 +118,7 @@ public partial class CompiledExpressionInterpreter
 		return result;
 	}
 
-	private async Task<CorDebugValue> CalculatePrimitiveOperand(
+	private async Task<ICorDebugValue> CalculatePrimitiveOperand(
 		OperationType opType,
 		CorDebugValue value,
 		LinkedList<EvalStackEntry> evalStack)
@@ -189,7 +189,7 @@ public partial class CompiledExpressionInterpreter
 		return null;
 	}
 
-	private async Task<CorDebugValue> CreateValueFromPrimitiveData(byte[] data)
+	private async Task<ICorDebugValue> CreateValueFromPrimitiveData(byte[] data)
 	{
 		if (data.Length == 1)
 			return await CreatePrimitiveValue(CorElementType.U1, data);

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
@@ -8,10 +8,10 @@ public partial class CompiledExpressionInterpreter
 	{
 		return elemType switch
 		{
-			CorElementType.Boolean => true,
+			CorElementType.BOOLEAN => true,
 			CorElementType.U1 => true,
 			CorElementType.I1 => true,
-			CorElementType.Char => true,
+			CorElementType.CHAR => true,
 			CorElementType.R8 => true,
 			CorElementType.R4 => true,
 			CorElementType.I4 => true,
@@ -20,7 +20,7 @@ public partial class CompiledExpressionInterpreter
 			CorElementType.U8 => true,
 			CorElementType.I2 => true,
 			CorElementType.U2 => true,
-			CorElementType.String => true,
+			CorElementType.STRING => true,
 			_ => false
 		};
 	}
@@ -42,13 +42,13 @@ public partial class CompiledExpressionInterpreter
 		var realValue1 = await GetRealValueWithType(value1!);
 		var elemType1 = realValue1.Type;
 
-		if (elemType1 == CorElementType.ValueType || elemType2 == CorElementType.ValueType ||
-			elemType1 == CorElementType.Class || elemType2 == CorElementType.Class)
+		if (elemType1 == CorElementType.VALUETYPE || elemType2 == CorElementType.VALUETYPE ||
+			elemType1 == CorElementType.CLASS || elemType2 == CorElementType.CLASS)
 		{
 			var opName = GetOperatorName(opType);
 			if (opName is not null)
 			{
-				if (elemType1 == CorElementType.ValueType || elemType1 == CorElementType.Class)
+				if (elemType1 == CorElementType.VALUETYPE || elemType1 == CorElementType.CLASS)
 				{
 					var result = await CallBinaryOperator(opName, realValue1, realValue1, realValue2);
 					if (result is not null)
@@ -58,7 +58,7 @@ public partial class CompiledExpressionInterpreter
 					}
 				}
 
-				if (elemType2 == CorElementType.ValueType || elemType2 == CorElementType.Class)
+				if (elemType2 == CorElementType.VALUETYPE || elemType2 == CorElementType.CLASS)
 				{
 					var result = await CallBinaryOperator(opName, realValue2, realValue1, realValue2);
 					if (result is not null)
@@ -83,7 +83,7 @@ public partial class CompiledExpressionInterpreter
 		var realValue = await GetRealValueWithType(value!);
 		var elemType = realValue.Type;
 
-		if (elemType == CorElementType.ValueType || elemType == CorElementType.Class)
+		if (elemType == CorElementType.VALUETYPE || elemType == CorElementType.CLASS)
 		{
 			var opName = GetUnaryOperatorName(opType);
 			if (opName is not null)

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
@@ -165,7 +165,7 @@ public partial class CompiledExpressionInterpreter
 		return await eval.CallParameterizedFunctionAsync(_debuggerManagedCallback, _debugger.EvalStatus, corDebugFunction, 0, null, evalArgs.Length, evalArgs);
 	}
 
-	private async Task<CorDebugFunction?> FindOperatorMethod(
+	private async Task<ICorDebugFunction?> FindOperatorMethod(
 		ICorDebugObjectValue objectValue,
 		string opName,
 		int paramCount)

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
@@ -104,8 +104,8 @@ public partial class CompiledExpressionInterpreter
 
 	private async Task<ICorDebugValue> CalculatePrimitiveOperands(
 		OperationType opType,
-		CorDebugValue value1,
-		CorDebugValue value2,
+		ICorDebugValue value1,
+		ICorDebugValue value2,
 		LinkedList<EvalStackEntry> evalStack)
 	{
 		var (data1, type1) = await GetOperandDataTypeByValue(value1);
@@ -120,7 +120,7 @@ public partial class CompiledExpressionInterpreter
 
 	private async Task<ICorDebugValue> CalculatePrimitiveOperand(
 		OperationType opType,
-		CorDebugValue value,
+		ICorDebugValue value,
 		LinkedList<EvalStackEntry> evalStack)
 	{
 		var (data, type) = await GetOperandDataTypeByValue(value);
@@ -132,28 +132,28 @@ public partial class CompiledExpressionInterpreter
 		return result;
 	}
 
-	private async Task<CorDebugValue?> CallBinaryOperator(
+	private async Task<ICorDebugValue?> CallBinaryOperator(
 		string opName,
-		CorDebugValue baseValue,
-		CorDebugValue arg1,
-		CorDebugValue arg2)
+		ICorDebugValue baseValue,
+		ICorDebugValue arg1,
+		ICorDebugValue arg2)
 	{
-		if (baseValue is not CorDebugObjectValue objectValue)
+		if (baseValue is not ICorDebugObjectValue objectValue)
 			return null;
 
 		var corDebugFunction = await FindOperatorMethod(objectValue, opName, 2);
 		if (corDebugFunction is null) return null;
 
 		var eval = _context.Thread.CreateEval();
-		ICorDebugValue[] evalArgs = [arg1.Raw, arg2.Raw];
+		ICorDebugValue[] evalArgs = [arg1, arg2];
 		return await eval.CallParameterizedFunctionAsync(_debuggerManagedCallback, _debugger.EvalStatus, corDebugFunction, 0, null, evalArgs.Length, evalArgs);
 	}
 
-	private async Task<CorDebugValue?> CallUnaryOperator(
+	private async Task<ICorDebugValue?> CallUnaryOperator(
 		string opName,
-		CorDebugValue baseValue)
+		ICorDebugValue baseValue)
 	{
-		if (baseValue is not CorDebugObjectValue objectValue)
+		if (baseValue is not ICorDebugObjectValue objectValue)
 			return null;
 
 		var corDebugFunction = await FindOperatorMethod(objectValue, opName, 1);
@@ -161,12 +161,12 @@ public partial class CompiledExpressionInterpreter
 			return null;
 
 		var eval = _context.Thread.CreateEval();
-		ICorDebugValue[] evalArgs = [baseValue.Raw];
+		ICorDebugValue[] evalArgs = [baseValue];
 		return await eval.CallParameterizedFunctionAsync(_debuggerManagedCallback, _debugger.EvalStatus, corDebugFunction, 0, null, evalArgs.Length, evalArgs);
 	}
 
 	private async Task<CorDebugFunction?> FindOperatorMethod(
-		CorDebugObjectValue objectValue,
+		ICorDebugObjectValue objectValue,
 		string opName,
 		int paramCount)
 	{

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_OperatorCalculator.cs
@@ -172,7 +172,7 @@ public partial class CompiledExpressionInterpreter
 	{
 		var objClass = objectValue.Class;
 		var module = objClass.Module;
-		var metaDataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		var classToken = objClass.Token;
 
 		var methods = metaDataImport.EnumMethods(classToken);

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_ValueCreation.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_ValueCreation.cs
@@ -4,7 +4,7 @@ namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 
 public partial class CompiledExpressionInterpreter
 {
-	private async Task<CorDebugValue> CreatePrimitiveValue(CorElementType type, byte[]? valueData)
+	private async Task<ICorDebugValue> CreatePrimitiveValue(CorElementType type, byte[]? valueData)
 	{
 		var eval = _context.Thread.CreateEval();
 		var corValue = eval.CreateValue(type, null);
@@ -24,20 +24,20 @@ public partial class CompiledExpressionInterpreter
 		return corValue;
 	}
 
-	private async Task<CorDebugValue> CreateBooleanValue(bool value)
+	private async Task<ICorDebugValue> CreateBooleanValue(bool value)
 	{
 		var eval = _context.Thread.CreateEval();
 		var corValue = eval.NewBooleanValue(value);
 		return corValue;
 	}
 
-	private async Task<CorDebugValue> CreateNullValue()
+	private async Task<ICorDebugValue> CreateNullValue()
 	{
 		var eval = _context.Thread.CreateEval();
 		return eval.CreateValue(CorElementType.Class, null);
 	}
 
-	private async Task<CorDebugValue> CreateValueType(CorDebugClass valueTypeClass, byte[]? valueData)
+	private async Task<ICorDebugValue> CreateValueType(CorDebugClass valueTypeClass, byte[]? valueData)
 	{
 		var eval = _context.Thread.CreateEval();
 		var corValue = await eval.NewParameterizedObjectNoConstructorAsync(_debuggerManagedCallback, _debugger.EvalStatus, valueTypeClass, 0, null);
@@ -60,7 +60,7 @@ public partial class CompiledExpressionInterpreter
 		throw new InvalidOperationException("Failed to create value type");
 	}
 
-	private async Task<CorDebugValue> CreateString(string str)
+	private async Task<ICorDebugValue> CreateString(string str)
 	{
 		var eval = _context.Thread.CreateEval();
 		return await eval.NewStringAsync(_debuggerManagedCallback, _debugger.EvalStatus, str);

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_ValueCreation.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_ValueCreation.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_ValueCreation.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/CompiledExpressionInterpreter_ValueCreation.cs
@@ -9,7 +9,7 @@ public partial class CompiledExpressionInterpreter
 		var eval = _context.Thread.CreateEval();
 		var corValue = eval.CreateValue(type, null);
 
-		if (valueData is not null && corValue is CorDebugGenericValue genValue)
+		if (valueData is not null && corValue is ICorDebugGenericValue genValue)
 		{
 			unsafe
 			{
@@ -34,10 +34,10 @@ public partial class CompiledExpressionInterpreter
 	private async Task<ICorDebugValue> CreateNullValue()
 	{
 		var eval = _context.Thread.CreateEval();
-		return eval.CreateValue(CorElementType.Class, null);
+		return eval.CreateValue(CorElementType.CLASS, null);
 	}
 
-	private async Task<ICorDebugValue> CreateValueType(CorDebugClass valueTypeClass, byte[]? valueData)
+	private async Task<ICorDebugValue> CreateValueType(ICorDebugClass valueTypeClass, byte[]? valueData)
 	{
 		var eval = _context.Thread.CreateEval();
 		var corValue = await eval.NewParameterizedObjectNoConstructorAsync(_debuggerManagedCallback, _debugger.EvalStatus, valueTypeClass, 0, null);
@@ -45,7 +45,7 @@ public partial class CompiledExpressionInterpreter
 		if (valueData is not null && corValue is not null)
 		{
 			var unwrapped = corValue.UnwrapDebugValue();
-			var unwrappedAsGeneric = unwrapped.As<CorDebugGenericValue>(); // a CorDebugObjectValue can also be a CorDebugGenericValue when it is a value class
+			var unwrappedAsGeneric = (ICorDebugGenericValue)unwrapped; // a CorDebugObjectValue can also be a CorDebugGenericValue when it is a value class
 			unsafe
 			{
 				fixed (byte* p = valueData)

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/EvalStackEntry.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/EvalStackEntry.cs
@@ -4,9 +4,9 @@ namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 
 public class EvalStackEntry
 {
-	public CorDebugValue? CorDebugValue { get; set; }
+	public ICorDebugValue? CorDebugValue { get; set; }
 	public List<string> Identifiers { get; set; } = new();
-	public List<CorDebugType?>? GenericTypeCache { get; set; }
+	public List<ICorDebugType?>? GenericTypeCache { get; set; }
 	public bool Literal { get; set; }
 	public bool Editable { get; set; }
 	public bool PreventBinding { get; set; }
@@ -40,6 +40,6 @@ public class EvalStackEntry
 
 public class SetterData
 {
-	public CorDebugValue? OwnerValue { get; set; }
-	public CorDebugFunction? SetterFunction { get; set; }
+	public ICorDebugValue? OwnerValue { get; set; }
+	public ICorDebugFunction? SetterFunction { get; set; }
 }

--- a/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/EvalStackEntry.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ExpressionEvaluator/Interpreter/EvalStackEntry.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 

--- a/src/SharpDbg.Infrastructure/Debugger/Extensions.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/Extensions.cs
@@ -73,7 +73,7 @@ public static class Extensions
 	public static mdTypeDef? FindTypeDefByNameOrNull(this MetaDataImport metadataImport, string typeName, mdToken enclosingClass)
 	{
 		var result = metadataImport.TryFindTypeDefByName(typeName, enclosingClass, out var mdTypeDef);
-		if (result is HRESULT.S_OK) return mdTypeDef;
+		if (result is Cor.S_OK) return mdTypeDef;
 		return null;
 	}
 
@@ -83,7 +83,7 @@ public static class Extensions
 		{
 			var fullTypeName = string.IsNullOrEmpty(candidateNamespace) ? typeName : $"{candidateNamespace}.{typeName}";
 			var result = metadataImport.TryFindTypeDefByName(fullTypeName, enclosingClass, out var mdTypeDef);
-			if (result is HRESULT.S_OK) return mdTypeDef;
+			if (result is Cor.S_OK) return mdTypeDef;
 		}
 		return null;
 	}
@@ -119,7 +119,7 @@ public static class Extensions
 	{
 		foreach (var attributeName in attributeNames)
 		{
-			if (metadataImport.TryGetCustomAttributeByName(token, attributeName, out _) is HRESULT.S_OK)
+			if (metadataImport.TryGetCustomAttributeByName(token, attributeName, out _) is Cor.S_OK)
 			{
 				return true;
 			}
@@ -147,7 +147,7 @@ public static class Extensions
 			e =>
 			{
 				var getResultResult = e.Eval.TryGetResult(out var result);
-				if (getResultResult is not HRESULT.CORDBG_S_FUNC_EVAL_HAS_NO_RESULT && result is null) getResultResult.ThrowOnNotOK();
+				if (getResultResult is not Cor.CORDBG_S_FUNC_EVAL_HAS_NO_RESULT && result is null) getResultResult.ThrowOnNotOK();
 				return result;
 			});
 	}

--- a/src/SharpDbg.Infrastructure/Debugger/Extensions.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/Extensions.cs
@@ -1,6 +1,6 @@
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
 

--- a/src/SharpDbg.Infrastructure/Debugger/Extensions.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/Extensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
@@ -7,14 +8,14 @@ namespace SharpDbg.Infrastructure.Debugger;
 public static class Extensions
 {
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool IsLiteral(this mdFieldDef mdFieldDef, MetaDataImport metadataImport)
+	public static bool IsLiteral(this mdFieldDef mdFieldDef, IMetaDataImport metadataImport)
 	{
 		var fieldProps = metadataImport.GetFieldProps(mdFieldDef);
 		var isStatic = fieldProps.pdwAttr.IsFdLiteral();
 		return isStatic;
 	}
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool IsStatic(this mdFieldDef mdFieldDef, MetaDataImport metadataImport)
+	public static bool IsStatic(this mdFieldDef mdFieldDef, IMetaDataImport metadataImport)
 	{
 		var fieldProps = metadataImport.GetFieldProps(mdFieldDef);
 		var isStatic = fieldProps.pdwAttr.IsFdStatic();
@@ -22,7 +23,7 @@ public static class Extensions
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool IsPublic(this mdFieldDef mdFieldDef, MetaDataImport metadataImport)
+	public static bool IsPublic(this mdFieldDef mdFieldDef, IMetaDataImport metadataImport)
 	{
 		var fieldProps = metadataImport.GetFieldProps(mdFieldDef);
 		var isPublic = fieldProps.pdwAttr.IsFdPublic();
@@ -30,7 +31,7 @@ public static class Extensions
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool IsPublic(this mdProperty mdProperty, MetaDataImport metadataImport)
+	public static bool IsPublic(this mdProperty mdProperty, IMetaDataImport metadataImport)
 	{
 		var propertyProps = metadataImport.GetPropertyProps(mdProperty);
 		var getterMethodProps = metadataImport.GetMethodProps(propertyProps.pmdGetter);
@@ -39,7 +40,7 @@ public static class Extensions
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool IsStatic(this mdProperty mdProperty, MetaDataImport metadataImport)
+	public static bool IsStatic(this mdProperty mdProperty, IMetaDataImport metadataImport)
 	{
 		var propertyProps = metadataImport.GetPropertyProps(mdProperty);
 		var getterMethodProps = metadataImport.GetMethodProps(propertyProps.pmdGetter);
@@ -48,7 +49,7 @@ public static class Extensions
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static bool IsStatic(this mdMethodDef methodToken, MetaDataImport metaDataImport)
+	public static bool IsStatic(this mdMethodDef methodToken, IMetaDataImport metaDataImport)
 	{
 		var methodProps = metaDataImport.GetMethodProps(methodToken);
 		var isStatic = methodProps.pdwAttr.IsMdStatic();
@@ -56,7 +57,7 @@ public static class Extensions
 	}
 
 	// To my knowledge, only strings from CustomAttributes 'Type' ctor use this '+' format
-	public static mdTypeDef? FindMaybeNestedTypeDefByNameOrNull(this MetaDataImport metadataImport, string typeName)
+	public static mdTypeDef? FindMaybeNestedTypeDefByNameOrNull(this IMetaDataImport metadataImport, string typeName)
 	{
 		var nestedClasses = typeName.Split('+');
 		mdTypeDef? enclosingClass = null;
@@ -70,14 +71,14 @@ public static class Extensions
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static mdTypeDef? FindTypeDefByNameOrNull(this MetaDataImport metadataImport, string typeName, mdToken enclosingClass)
+	public static mdTypeDef? FindTypeDefByNameOrNull(this IMetaDataImport metadataImport, string typeName, mdToken enclosingClass)
 	{
 		var result = metadataImport.TryFindTypeDefByName(typeName, enclosingClass, out var mdTypeDef);
 		if (result is Cor.S_OK) return mdTypeDef;
 		return null;
 	}
 
-	public static mdTypeDef? FindTypeDefByNameOrNullInCandidateNamespaces(this MetaDataImport metadataImport, string typeName, mdToken enclosingClass, ImmutableArray<string> candidateNamespaces)
+	public static mdTypeDef? FindTypeDefByNameOrNullInCandidateNamespaces(this IMetaDataImport metadataImport, string typeName, mdToken enclosingClass, ImmutableArray<string> candidateNamespaces)
 	{
 		foreach (var candidateNamespace in candidateNamespaces)
 		{
@@ -98,7 +99,7 @@ public static class Extensions
 		return false;
 	}
 
-	public static mdProperty? GetPropertyWithName(this MetaDataImport metaDataImport, mdTypeDef mdTypeDef, string propertyName)
+	public static mdProperty? GetPropertyWithName(this IMetaDataImport metaDataImport, mdTypeDef mdTypeDef, string propertyName)
 	{
 		var properties = metaDataImport.EnumProperties(mdTypeDef);
 
@@ -115,11 +116,11 @@ public static class Extensions
 		return null;
 	}
 
-	public static bool HasAnyAttribute(this MetaDataImport metadataImport, mdToken token, string[] attributeNames)
+	public static bool HasAnyAttribute(this IMetaDataImport metadataImport, mdToken token, string[] attributeNames)
 	{
 		foreach (var attributeName in attributeNames)
 		{
-			if (metadataImport.TryGetCustomAttributeByName(token, attributeName, out _) is Cor.S_OK)
+			if (metadataImport.TryGetCustomAttributeByName(token, attributeName, out _, out _) is Cor.S_OK)
 			{
 				return true;
 			}
@@ -127,55 +128,55 @@ public static class Extensions
 		return false;
 	}
 
-	public static async Task<CorDebugValue?> CallParameterlessInstanceMethodAsync(this CorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, CorDebugFunction corDebugFunction, CorDebugValue corDebugValue)
+	public static async Task<ICorDebugValue?> CallParameterlessInstanceMethodAsync(this ICorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, ICorDebugFunction corDebugFunction, ICorDebugValue corDebugValue)
 	{
 		const bool isStatic = false;
 
-		var typeParameterArgs = corDebugValue.ExactType.TypeParameters.Select(t => t.Raw).ToArray();
+		var typeParameterArgs = corDebugValue.ExactType.TypeParameters;
 
 		// For instance properties, pass the object; for static, pass nothing. Must pass the original CorDebugReferenceValue, not the dereferenced one.
-		ICorDebugValue[] corDebugValues = isStatic ? [] : [corDebugValue!.Raw];
+		ICorDebugValue[] corDebugValues = isStatic ? [] : [corDebugValue];
 		var result = await eval.CallParameterizedFunctionAsync(managedCallback, evalStatus, corDebugFunction, typeParameterArgs.Length, typeParameterArgs, corDebugValues.Length, corDebugValues);
 		return result;
 	}
 
-	public static async Task<CorDebugValue?> CallParameterizedFunctionAsync(this CorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, CorDebugFunction corDebugFunction, int typeParamCount, ICorDebugType[]? typeParameterArgs, int paramCount, ICorDebugValue[] corDebugValues)
+	public static async Task<ICorDebugValue?> CallParameterizedFunctionAsync(this ICorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, ICorDebugFunction corDebugFunction, int typeParamCount, ICorDebugType[]? typeParameterArgs, int paramCount, ICorDebugValue[] corDebugValues)
 	{
 		// Ensure that the object passed in corDebugValues is a CorDebugReferenceValue (when containing object is an instance class), ie must not be dereferenced
 		return await RunEvalAsync(eval, managedCallback, evalStatus,
-			() => eval.CallParameterizedFunction(corDebugFunction.Raw, typeParamCount, typeParameterArgs, paramCount, corDebugValues),
+			() => eval.CallParameterizedFunction(corDebugFunction, typeParamCount, typeParameterArgs, paramCount, corDebugValues),
 			e =>
 			{
 				var getResultResult = e.Eval.TryGetResult(out var result);
-				if (getResultResult is not Cor.CORDBG_S_FUNC_EVAL_HAS_NO_RESULT && result is null) getResultResult.ThrowOnNotOK();
+				if (getResultResult is not Cor.CORDBG_S_FUNC_EVAL_HAS_NO_RESULT && result is null) Marshal.ThrowExceptionForHR(getResultResult);
 				return result;
 			});
 	}
 
-	public static async Task<CorDebugValue?> NewParameterizedObjectNoConstructorAsync(this CorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, CorDebugClass pClass, int nTypeArgs, ICorDebugType[]? ppTypeArgs)
+	public static async Task<ICorDebugValue?> NewParameterizedObjectNoConstructorAsync(this ICorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, ICorDebugClass pClass, int nTypeArgs, ICorDebugType[]? ppTypeArgs)
 	{
 		return await RunEvalAsync(eval, managedCallback, evalStatus,
-			() => eval.NewParameterizedObjectNoConstructor(pClass.Raw, nTypeArgs, ppTypeArgs),
+			() => eval.NewParameterizedObjectNoConstructor(pClass, nTypeArgs, ppTypeArgs),
 			e => e.Eval.Result);
 	}
 
-	public static async Task<CorDebugValue?> NewParameterizedObjectAsync(this CorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, CorDebugFunction corDebugFunction, int nTypeArgs, ICorDebugType[]? ppTypeArgs, int argCount, ICorDebugValue[] argValues)
+	public static async Task<ICorDebugValue?> NewParameterizedObjectAsync(this ICorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, ICorDebugFunction corDebugFunction, int nTypeArgs, ICorDebugType[]? ppTypeArgs, int argCount, ICorDebugValue[] argValues)
 	{
 		return await RunEvalAsync(eval, managedCallback, evalStatus,
-			() => eval.NewParameterizedObject(corDebugFunction.Raw, nTypeArgs, ppTypeArgs, argCount, argValues),
+			() => eval.NewParameterizedObject(corDebugFunction, nTypeArgs, ppTypeArgs, argCount, argValues),
 			e => e.Eval.Result);
 	}
 
-	public static async Task<CorDebugValue> NewStringAsync(this CorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, string str)
+	public static async Task<ICorDebugValue> NewStringAsync(this ICorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, string str)
 	{
 		return (await RunEvalAsync(eval, managedCallback, evalStatus,
 			() => eval.NewString(str),
 			e => e.Eval.Result))!;
 	}
 
-	private static async Task<CorDebugValue?> RunEvalAsync(CorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, Action startEval, Func<EvalCompleteCorDebugManagedCallbackEventArgs, CorDebugValue?> onComplete)
+	private static async Task<ICorDebugValue?> RunEvalAsync(ICorDebugEval eval, CorDebugManagedCallback managedCallback, EvalStatus evalStatus, Action startEval, Func<EvalCompleteCorDebugManagedCallbackEventArgs, ICorDebugValue?> onComplete)
 	{
-		CorDebugValue? returnValue = null;
+		ICorDebugValue? returnValue = null;
 		var evalCompleteTcs = new TaskCompletionSource();
 		try
 		{
@@ -197,13 +198,13 @@ public static class Extensions
 		}
 		void OnEvalComplete(object? s, EvalCompleteCorDebugManagedCallbackEventArgs e)
 		{
-			if (e.Eval.Raw != eval.Raw) return;
+			if (e.Eval != eval) return;
 			returnValue = onComplete(e);
 			evalCompleteTcs.SetResult();
 		}
 		void OnEvalException(object? sender, EvalExceptionCorDebugManagedCallbackEventArgs e)
 		{
-			if (e.Eval.Raw != eval.Raw) return;
+			if (e.Eval != eval) return;
 			if (e.Eval.Result is null)
 			{
 				evalCompleteTcs.SetException(new ManagedDebugger.EvalException("EvalException callback error - Result is null"));
@@ -215,11 +216,11 @@ public static class Extensions
 		}
 	}
 
-	public static CorDebugValue NewBooleanValue(this CorDebugEval eval, bool value)
+	public static ICorDebugValue NewBooleanValue(this ICorDebugEval eval, bool value)
 	{
-		var corValue = eval.CreateValue(CorElementType.Boolean, null);
+		var corValue = eval.CreateValue(CorElementType.BOOLEAN, null);
 
-		if (value is true && corValue is CorDebugGenericValue genValue)
+		if (value is true && corValue is ICorDebugGenericValue genValue)
 		{
 			var size = genValue.Size;
 			var valueData = new byte[size];

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
@@ -326,11 +326,11 @@ public partial class ManagedDebugger
 		foreach (var bp in _breakpointManager.GetAllBreakpoints().Where(b => b.CorBreakpoint is not null))
 		{
 			var hResult = bp.CorBreakpoint!.TryActivate(false);
-			if (hResult is HRESULT.CORDBG_E_PROCESS_TERMINATED)
+			if (hResult is Cor.CORDBG_E_PROCESS_TERMINATED)
 			{
 				break;
 			}
-			if (hResult is not HRESULT.S_OK) _logger?.Invoke($"Failed to deactivate breakpoint during Dispose at {bp.FilePath}:{bp.Line}: {hResult}");
+			if (hResult is not Cor.S_OK) _logger?.Invoke($"Failed to deactivate breakpoint during Dispose at {bp.FilePath}:{bp.Line}: {hResult}");
 		}
 		_breakpointManager.Clear();
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
@@ -13,14 +13,14 @@ namespace SharpDbg.Infrastructure.Debugger;
 // v1 of this class was AI generated, and could definitely do with some cleaning up
 public partial class ManagedDebugger
 {
-	private CorDebug? _corDebug;
-	private CorDebugProcess? _process;
+	private ICorDebug? _corDebug;
+	private ICorDebugProcess? _process;
 	private readonly CorDebugManagedCallback _callbacks;
 	private readonly BreakpointManager _breakpointManager;
 	private readonly VariableManager _variableManager;
 	private readonly FrameReferenceManager _frameReferenceManager;
 	private readonly Action<string>? _logger;
-	private readonly Dictionary<int, CorDebugThread> _threads = new();
+	private readonly Dictionary<int, ICorDebugThread> _threads = new();
 	private readonly Dictionary<CORDB_ADDRESS, ModuleInfo> _modules = new();
 	private bool _isAttached;
 	private bool _isRemoteAttach;
@@ -76,7 +76,7 @@ public partial class ManagedDebugger
 				case BreakCorDebugManagedCallbackEventArgs a: HandleBreak(sender, a); break;
 				case ExceptionCorDebugManagedCallbackEventArgs a: HandleException(sender, a); break;
 				case EvalCompleteCorDebugManagedCallbackEventArgs or EvalExceptionCorDebugManagedCallbackEventArgs: break; // don't continue on these, as they are being used for expression evaluation
-				default: e.Controller.Continue(false); break;
+				default: _process?.Continue(false); break;
 			}
 		}
 		catch (Exception ex)
@@ -148,18 +148,18 @@ public partial class ManagedDebugger
 		_process.Continue(false);
 	}
 
-	private CorDebugStepper? _stepper;
+	private ICorDebugStepper? _stepper;
 
 	/// <summary>
 	/// Setup a stepper without continuing execution
 	/// </summary>
-	internal CorDebugStepper SetupStepper(CorDebugThread thread, AsyncStepper.StepType stepType)
+	internal ICorDebugStepper SetupStepper(ICorDebugThread thread, AsyncStepper.StepType stepType)
 	{
 		var frame = thread.ActiveFrame;
-		if (frame is not CorDebugILFrame ilFrame) throw new InvalidOperationException("Active frame is not an IL frame");
+		if (frame is not ICorDebugILFrame ilFrame) throw new InvalidOperationException("Active frame is not an IL frame");
 		if (_stepper is not null) throw new InvalidOperationException("A step operation is already in progress");
 
-		CorDebugStepper stepper = frame.CreateStepper();
+		ICorDebugStepper stepper = frame.CreateStepper();
 		stepper.SetInterceptMask(CorDebugIntercept.INTERCEPT_ALL & ~(CorDebugIntercept.INTERCEPT_SECURITY | CorDebugIntercept.INTERCEPT_CLASS_INIT));
 		stepper.SetUnmappedStopMask(CorDebugUnmappedStop.STOP_NONE);
 		//stepper.SetJMC(true);
@@ -282,22 +282,22 @@ public partial class ManagedDebugger
 		}
 	}
 
-	internal CorDebugILFrame GetFrameForThreadIdAndStackDepth(ThreadId threadId, FrameStackDepth stackDepth)
+	internal ICorDebugILFrame GetFrameForThreadIdAndStackDepth(ThreadId threadId, FrameStackDepth stackDepth)
 	{
 		// We need to re-obtain the IlFrame in case it has been neutered
 		var thread = _process!.Threads.Single(s => s.Id == threadId.Value);
 		var frame = thread.ActiveChain.Frames[stackDepth.Value];
-		if (frame is not CorDebugILFrame ilFrame) throw new InvalidOperationException("Frame is not an IL frame");
+		if (frame is not ICorDebugILFrame ilFrame) throw new InvalidOperationException("Frame is not an IL frame");
 		return ilFrame;
 	}
 
-	private static string GetFunctionFormattedName(CorDebugFunction function)
+	private static string GetFunctionFormattedName(ICorDebugFunction function)
 	{
 		try
 		{
 			var token = function.Token;
 			var module = function.Module;
-			var metadataImport = module.GetMetaDataInterface().MetaDataImport;
+			var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 			var methodName = metadataImport.GetMethodProps(token).szMethod;
 
 			var @class = function.Class;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
@@ -99,10 +99,9 @@ public partial class ManagedDebugger
 		_logger?.Invoke($"Attaching to process: {processId}");
 
 		// Initialize the debugger
-		var dbgshim = new DbgShim(NativeLibrary.Load("dbgshim", typeof(ManagedDebugger).Assembly, null));
-		_ = Task.Run(() =>
+		_ = Task.Run(async () =>
 		{
-			_corDebug = ClrDebugExtensions.Automatic(dbgshim, processId);
+			_corDebug = await ClrDebugExtensions.Automatic(processId);
 			_corDebug.Initialize();
 			_corDebug.SetManagedHandler(_callbacks);
 
@@ -119,8 +118,7 @@ public partial class ManagedDebugger
 	{
 		_logger?.Invoke($"Attaching to remote process on {remoteAttachInfo.Address}:{remoteAttachInfo.Port}");
 
-		var dbgshim = new DbgShim(NativeLibrary.Load("dbgshim", typeof(ManagedDebugger).Assembly, null));
-		_corDebug = ClrDebugExtensions.Mobile(dbgshim, remoteAttachInfo);
+		_corDebug = ClrDebugExtensions.Mobile(remoteAttachInfo);
 		_corDebug.SetManagedHandler(_callbacks);
 		try
 		{

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Ardalis.GuardClauses;
-using ClrDebug;
+using ICorDebugSharp;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Compiler;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
@@ -182,8 +182,8 @@ public partial class ManagedDebugger
 				}
 				var stepRange = new COR_DEBUG_STEP_RANGE
 				{
-					startOffset = startIlOffset,
-					endOffset = endIlOffset
+					startOffset = checked((uint)startIlOffset),
+					endOffset = checked((uint)endIlOffset)
 				};
 				var stepIn = stepType is AsyncStepper.StepType.StepIn;
 				stepper.StepRange(stepIn, [stepRange], 1);

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_ConditionalBreakpoints.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_ConditionalBreakpoints.cs
@@ -1,5 +1,5 @@
 using System.Runtime.InteropServices;
-using ClrDebug;
+using ICorDebugSharp;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Compiler;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_ConditionalBreakpoints.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_ConditionalBreakpoints.cs
@@ -72,7 +72,7 @@ public partial class ManagedDebugger
 				genericValue.GetValue(buffer);
 				return genericValue.Type switch
 				{
-					CorElementType.Boolean => Marshal.ReadByte(buffer) != 0,
+					CorElementType.BOOLEAN => Marshal.ReadByte(buffer) != 0,
 					CorElementType.I1 or CorElementType.U1 => Marshal.ReadByte(buffer) != 0,
 					CorElementType.I2 or CorElementType.U2 => Marshal.ReadInt16(buffer) != 0,
 					CorElementType.I4 or CorElementType.U4 => Marshal.ReadInt32(buffer) != 0,

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_ConditionalBreakpoints.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_ConditionalBreakpoints.cs
@@ -7,7 +7,7 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public partial class ManagedDebugger
 {
-	private async Task<bool> EvaluateBreakpointCondition(CorDebugThread corThread, string condition)
+	private async Task<bool> EvaluateBreakpointCondition(ICorDebugThread corThread, string condition)
 	{
 		try
 		{
@@ -58,13 +58,13 @@ public partial class ManagedDebugger
 	/// <summary>
 	/// Check if a debug value is truthy (true, non-zero, non-null)
 	/// </summary>
-	private static bool IsTruthyValue(CorDebugValue? value)
+	private static bool IsTruthyValue(ICorDebugValue? value)
 	{
 		if (value is null) return false;
 
 		var unwrapped = value.UnwrapDebugValue();
 
-		if (unwrapped is CorDebugGenericValue genericValue)
+		if (unwrapped is ICorDebugGenericValue genericValue)
 		{
 			var buffer = Marshal.AllocHGlobal(genericValue.Size);
 			try
@@ -92,7 +92,7 @@ public partial class ManagedDebugger
 			}
 		}
 
-		if (unwrapped is CorDebugReferenceValue refValue)
+		if (unwrapped is ICorDebugReferenceValue refValue)
 		{
 			return !refValue.IsNull;
 		}

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
@@ -47,7 +47,7 @@ public partial class ManagedDebugger
 		var corModule = loadModuleCorDebugManagedCallbackEventArgs.Module;
 		var modulePath = corModule.Name;
 		var moduleName = Path.GetFileName(modulePath);
-		var baseAddress = (long)corModule.BaseAddress;
+		var baseAddress = corModule.BaseAddress;
 
 		_logger?.Invoke($"Module loaded: {modulePath} at 0x{baseAddress:X}");
 
@@ -59,7 +59,7 @@ public partial class ManagedDebugger
 			{
 				var size = corModule.Size;
 				var baseAddress2 = corModule.BaseAddress;
-				var bytes = _process.ReadMemory(baseAddress2, size);
+				var (bytes, _) = _process.ReadMemory(baseAddress2, size);
 				symbolReader = SymbolReader.TryLoadFromBytes(bytes);
 			}
 			else
@@ -130,7 +130,7 @@ public partial class ManagedDebugger
 			_stepper = null;
 		}
 
-		if (breakpoint is not CorDebugFunctionBreakpoint functionBreakpoint)
+		if (breakpoint is not ICorDebugFunctionBreakpoint functionBreakpoint)
 		{
 			_logger?.Invoke("Unknown breakpoint type hit");
 			Continue(); // may be incorrect
@@ -193,7 +193,7 @@ public partial class ManagedDebugger
 	private void HandleStepComplete(object? sender, StepCompleteCorDebugManagedCallbackEventArgs stepCompleteEventArgs)
 	{
 		var corThread = stepCompleteEventArgs.Thread;
-		var ilFrame = (CorDebugILFrame)corThread.ActiveFrame;
+		var ilFrame = (ICorDebugILFrame)corThread.ActiveFrame;
 		// If we have an active async stepper, it means we would have a breakpoint set up for either yield or resume for the next await statement
 		// We would then have done a regular step over/in/out to get to that breakpoint
 		// Since the step has completed, it means we did not hit the breakpoint, so we can clear the active async step

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
@@ -227,7 +227,7 @@ public partial class ManagedDebugger
 		if (nextUserCodeIlOffset is null)
 		{
 			// Check attributes
-			var metadataImport = ilFrame.Function.Module.GetMetaDataInterface().MetaDataImport;
+			var metadataImport = ilFrame.Function.Module.GetMetaDataInterface<IMetaDataImport>();
 			var mdMethodDef = ilFrame.Function.Token;
 			var methodIsNotDebuggable =
 				metadataImport.HasAnyAttribute(mdMethodDef, JmcConstants.JmcMethodAttributeNames);

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using ClrDebug;
+using ICorDebugSharp;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Interpreter;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
@@ -167,7 +167,7 @@ public partial class ManagedDebugger
 			}
 		}
 
-		var managedBreakpoint = _breakpointManager.FindByCorBreakpoint(functionBreakpoint.Raw);
+		var managedBreakpoint = _breakpointManager.FindByCorBreakpoint(functionBreakpoint);
 		ArgumentNullException.ThrowIfNull(managedBreakpoint);
 
 		managedBreakpoint.HitCount++;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_FrameSourceInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_FrameSourceInfo.cs
@@ -21,9 +21,9 @@ public record struct AssemblyPathAndMvid(string AssemblyPath, Guid Mvid);
 public partial class ManagedDebugger
 {
 	/// This appears to be 1 based, ie requires no adjustment when returned to the user
-	private SourceInfo? GetSourceInfoAtFrame(CorDebugFrame frame)
+	private SourceInfo? GetSourceInfoAtFrame(ICorDebugFrame frame)
 	{
-		if (frame is not CorDebugILFrame ilFrame)
+		if (frame is not ICorDebugILFrame ilFrame)
 			throw new InvalidOperationException("Active frame is not an IL frame");
 		var function = ilFrame.Function;
 		var module = _modules[function.Module.BaseAddress];
@@ -61,7 +61,7 @@ public partial class ManagedDebugger
 					{
 						if (caller is null) break;
 
-						if (caller is CorDebugILFrame callerIlFrame)
+						if (caller is ICorDebugILFrame callerIlFrame)
 						{
 							var callerFunction = callerIlFrame.Function;
 							var callerModule = _modules[callerFunction.Module.BaseAddress];

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_FrameSourceInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_FrameSourceInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection.PortableExecutable;
-using ClrDebug;
+using ICorDebugSharp;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.CSharp;
 using ICSharpCode.Decompiler.CSharp.Transforms;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_FrameSourceInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_FrameSourceInfo.cs
@@ -49,7 +49,7 @@ public partial class ManagedDebugger
 				DecompiledSourceInfo? decompiledSourceInfo = null;
 				if (module.SymbolReaderFromDecompiled)
 				{
-					var metadataImport = module.Module.GetMetaDataInterface().MetaDataImport;
+					var metadataImport = module.Module.GetMetaDataInterface<IMetaDataImport>();
 					var mvid = metadataImport.ScopeProps.pmvid;
 					var containingTypeDef = metadataImport.GetMethodProps(methodToken).pClass;
 					var typeProps = metadataImport.GetTypeDefProps(containingTypeDef);
@@ -93,7 +93,7 @@ public partial class ManagedDebugger
 	private SymbolReader? GetCachedOrGeneratePdb(ModuleInfo moduleInfo)
 	{
 		var sharpIdeSymbolCachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Temp", "SharpIdeSymbolCache");
-		var metadataImport = moduleInfo.Module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = moduleInfo.Module.GetMetaDataInterface<IMetaDataImport>();
 		var mvid = metadataImport.ScopeProps.pmvid;
 		var assemblyName = Path.GetFileNameWithoutExtension(moduleInfo.ModuleName);
 		var pdbPath = Path.Combine(sharpIdeSymbolCachePath, assemblyName, mvid.ToString(), $"{assemblyName}.decompiled.pdb");

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_IdentifierResolver.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_IdentifierResolver.cs
@@ -215,7 +215,7 @@ public partial class ManagedDebugger
 		return result;
 	}
 
-	private async Task<ICorDebugValue?> CreateTypeObjectStaticConstructor(CorDebugClass corDebugClass, ThreadId threadId, FrameStackDepth stackDepth)
+	private async Task<ICorDebugValue?> CreateTypeObjectStaticConstructor(ICorDebugClass corDebugClass, ThreadId threadId, FrameStackDepth stackDepth)
 	{
 		var ilFrame = GetFrameForThreadIdAndStackDepth(threadId, stackDepth);
 		var eval = ilFrame.Chain.Thread.CreateEval();
@@ -237,7 +237,7 @@ public partial class ManagedDebugger
 		return null;
 	}
 
-	private (mdTypeDef typeToken, int nextIdentifier)? FindTypeTokenInModule(CorDebugModule module, List<string> identifiers, ImmutableArray<string> importedNamespaces)
+	private (mdTypeDef typeToken, int nextIdentifier)? FindTypeTokenInModule(ICorDebugModule module, List<string> identifiers, ImmutableArray<string> importedNamespaces)
 	{
 		var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		mdTypeDef? typeToken = null;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_IdentifierResolver.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_IdentifierResolver.cs
@@ -1,5 +1,5 @@
 using System.Collections.Immutable;
-using ClrDebug;
+using ICorDebugSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace SharpDbg.Infrastructure.Debugger;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_IdentifierResolver.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_IdentifierResolver.cs
@@ -9,7 +9,7 @@ public partial class ManagedDebugger
 	// e.g. localVar, or localVar.Field1.Field2, or ClassName.StaticField.SubField
 	// optionalInputValue may be provided, e.g. in the case of where the value was created in the evaluation and does not exist
 	// as a local in the stack frame.
-	public async Task<CorDebugValue> ResolveIdentifiers(List<string> identifiers, ThreadId threadId, FrameStackDepth stackDepth, CorDebugValue? optionalInputValue, CorDebugValue? optionalRootValue)
+	public async Task<ICorDebugValue> ResolveIdentifiers(List<string> identifiers, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue? optionalInputValue, ICorDebugValue? optionalRootValue)
 	{
 		if (identifiers.Count is 0)
 		{
@@ -37,7 +37,7 @@ public partial class ManagedDebugger
 	// Only takes the full list as resolving it as a static class needs to e.g. search through namespaces
 	// We must return the next identifier index to process after the static class name
 	// An optional root value is supplied if the identifiers should be resolved against it only, e.g. for DebuggerDisplay expressions
-	private async Task<(CorDebugValue Value, int? NextIdentifier)> ResolveFirstIdentifier(List<string> identifiers, ThreadId threadId, FrameStackDepth stackDepth, CorDebugValue? optionalRootValue)
+	private async Task<(ICorDebugValue Value, int? NextIdentifier)> ResolveFirstIdentifier(List<string> identifiers, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue? optionalRootValue)
 	{
 		var firstIdentifier = identifiers[0];
 		ArgumentException.ThrowIfNullOrWhiteSpace(firstIdentifier);
@@ -45,8 +45,8 @@ public partial class ManagedDebugger
 		// 1. Stack variable, e.g. local variable or argument
 		// 2. Field or property of 'this' if available (instance or static)
 		// 3. Identifier as static class name
-		CorDebugValue? resolvedValue = null;
-		CorDebugValue? instanceMethodImplicitThisValue = optionalRootValue;
+		ICorDebugValue? resolvedValue = null;
+		ICorDebugValue? instanceMethodImplicitThisValue = optionalRootValue;
 
 		if (optionalRootValue is null) resolvedValue = ResolveIdentifierAsStackVariable(firstIdentifier, threadId, stackDepth, out instanceMethodImplicitThisValue);
 		if (resolvedValue is not null) return (resolvedValue, null);
@@ -59,7 +59,7 @@ public partial class ManagedDebugger
 		throw new InvalidOperationException($"Could not resolve identifier '{firstIdentifier}' as a stack variable.");
 	}
 
-	private CorDebugValue? ResolveIdentifierAsStackVariable(string identifier, ThreadId threadId, FrameStackDepth stackDepth, out CorDebugValue? instanceMethodImplicitThisValue)
+	private ICorDebugValue? ResolveIdentifierAsStackVariable(string identifier, ThreadId threadId, FrameStackDepth stackDepth, out ICorDebugValue? instanceMethodImplicitThisValue)
 	{
 		instanceMethodImplicitThisValue = null;
 
@@ -148,7 +148,7 @@ public partial class ManagedDebugger
 	/// Searches the closure chain starting at <paramref name="closureValue"/> for a hoisted local
 	/// whose original name matches <paramref name="identifier"/>. Walks parent closures linked via
 	/// <see cref="GeneratedNameKind.DisplayClassLocalOrField"/> fields.
-	private static CorDebugValue? FindHoistedLocalInClosureChain(CorDebugValue closureValue, string identifier, MetaDataImport metadataImport)
+	private static ICorDebugValue? FindHoistedLocalInClosureChain(ICorDebugValue closureValue, string identifier, IMetaDataImport metadataImport)
 	{
 		var objectValue = closureValue.UnwrapDebugValueToObject();
 		var fields = metadataImport.EnumFields(objectValue.Class.Token);
@@ -160,11 +160,11 @@ public partial class ManagedDebugger
 			if (kind is GeneratedNameKind.HoistedLocalField)
 			{
 				var originalName = fieldName.AsSpan()[(openBracketOffset + 1)..closeBracketOffset].ToString();
-				if (originalName == identifier) return objectValue.GetFieldValue(objectValue.Class.Raw, field);
+				if (originalName == identifier) return objectValue.GetFieldValue(objectValue.Class, field);
 			}
 			else if (kind is GeneratedNameKind.DisplayClassLocalOrField)
 			{
-				var parentClosureValue = objectValue.GetFieldValue(objectValue.Class.Raw, field);
+				var parentClosureValue = objectValue.GetFieldValue(objectValue.Class, field);
 				var parentObjectValue = parentClosureValue.UnwrapDebugValueToObject();
 				var parentMetadata = parentObjectValue.Class.Module.GetMetaDataInterface<IMetaDataImport>();
 				var result = FindHoistedLocalInClosureChain(parentClosureValue, identifier, parentMetadata);
@@ -174,7 +174,7 @@ public partial class ManagedDebugger
 		return null;
 	}
 
-	private async Task<CorDebugValue?> ResolveIdentifierAsMember(string identifier, ThreadId threadId, FrameStackDepth stackDepth, CorDebugValue instanceMethodImplicitThisValue)
+	private async Task<ICorDebugValue?> ResolveIdentifierAsMember(string identifier, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue instanceMethodImplicitThisValue)
 	{
 		var unwrappedThisValue = instanceMethodImplicitThisValue.UnwrapDebugValueToObject();
 		var frame = GetFrameForThreadIdAndStackDepth(threadId, stackDepth);
@@ -186,7 +186,7 @@ public partial class ManagedDebugger
 		return null;
 	}
 
-	private async Task<(CorDebugValue Value, int NextIdentifier)?> ResolveStaticClassFromIdentifiers(List<string> identifiers, ThreadId threadId, FrameStackDepth stackDepth)
+	private async Task<(ICorDebugValue Value, int NextIdentifier)?> ResolveStaticClassFromIdentifiers(List<string> identifiers, ThreadId threadId, FrameStackDepth stackDepth)
 	{
 		// First, try to resolve using imported namespaces from the current method's PDB symbols
 		var typeTokenResult = FindTypeTokenInLoadedModulesWithNamespaceHints(identifiers, threadId, stackDepth);
@@ -215,7 +215,7 @@ public partial class ManagedDebugger
 		return result;
 	}
 
-	private async Task<CorDebugValue?> CreateTypeObjectStaticConstructor(CorDebugClass corDebugClass, ThreadId threadId, FrameStackDepth stackDepth)
+	private async Task<ICorDebugValue?> CreateTypeObjectStaticConstructor(CorDebugClass corDebugClass, ThreadId threadId, FrameStackDepth stackDepth)
 	{
 		var ilFrame = GetFrameForThreadIdAndStackDepth(threadId, stackDepth);
 		var eval = ilFrame.Chain.Thread.CreateEval();

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_IdentifierResolver.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_IdentifierResolver.cs
@@ -84,7 +84,7 @@ public partial class ManagedDebugger
 			}
 		}
 
-		var metadataImport = module.Module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = module.Module.GetMetaDataInterface<IMetaDataImport>();
 		var methodProps = metadataImport!.GetMethodProps(corDebugFunction.Token);
 		var isStatic = methodProps.pdwAttr.IsMdStatic();
 		var methodName = methodProps.szMethod;
@@ -166,7 +166,7 @@ public partial class ManagedDebugger
 			{
 				var parentClosureValue = objectValue.GetFieldValue(objectValue.Class.Raw, field);
 				var parentObjectValue = parentClosureValue.UnwrapDebugValueToObject();
-				var parentMetadata = parentObjectValue.Class.Module.GetMetaDataInterface().MetaDataImport;
+				var parentMetadata = parentObjectValue.Class.Module.GetMetaDataInterface<IMetaDataImport>();
 				var result = FindHoistedLocalInClosureChain(parentClosureValue, identifier, parentMetadata);
 				if (result is not null) return result;
 			}
@@ -239,7 +239,7 @@ public partial class ManagedDebugger
 
 	private (mdTypeDef typeToken, int nextIdentifier)? FindTypeTokenInModule(CorDebugModule module, List<string> identifiers, ImmutableArray<string> importedNamespaces)
 	{
-		var metadataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		mdTypeDef? typeToken = null;
 
 		string currentTypeName = string.Empty;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_MapPrimitiveTypesToClass.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_MapPrimitiveTypesToClass.cs
@@ -1,5 +1,5 @@
 using System.Runtime.InteropServices;
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_MapPrimitiveTypesToClass.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_MapPrimitiveTypesToClass.cs
@@ -5,11 +5,11 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public partial class ManagedDebugger
 {
-	public Dictionary<CorElementType, CorDebugClass> CorElementToValueClassMap { get; set; } = [];
-	public CorDebugClass? CorDecimalClass { get; set; }
-	public CorDebugClass? CorVoidClass { get; set; }
+	public Dictionary<CorElementType, ICorDebugClass> CorElementToValueClassMap { get; set; } = [];
+	public ICorDebugClass? CorDecimalClass { get; set; }
+	public ICorDebugClass? CorVoidClass { get; set; }
 
-	private void MapRuntimePrimitiveTypesToCorDebugClass(CorDebugModule module)
+	private void MapRuntimePrimitiveTypesToCorDebugClass(ICorDebugModule module)
 	{
 		if (Path.GetFileName(module.Name) is not "System.Private.CoreLib.dll") throw new InvalidOperationException("Mapping primitive types to classes is only supported for System.Private.CoreLib.dll");
 		var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_MapPrimitiveTypesToClass.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_MapPrimitiveTypesToClass.cs
@@ -24,8 +24,8 @@ public partial class ManagedDebugger
 
 		var corElementToValueNameMap = new[]
 		{
-			(CorElementType.Boolean, "System.Boolean"),
-			(CorElementType.Char, "System.Char"),
+			(CorElementType.BOOLEAN, "System.Boolean"),
+			(CorElementType.CHAR, "System.Char"),
 			(CorElementType.I1, "System.SByte"),
 			(CorElementType.U1, "System.Byte"),
 			(CorElementType.I2, "System.Int16"),

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_MapPrimitiveTypesToClass.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_MapPrimitiveTypesToClass.cs
@@ -12,7 +12,7 @@ public partial class ManagedDebugger
 	private void MapRuntimePrimitiveTypesToCorDebugClass(CorDebugModule module)
 	{
 		if (Path.GetFileName(module.Name) is not "System.Private.CoreLib.dll") throw new InvalidOperationException("Mapping primitive types to classes is only supported for System.Private.CoreLib.dll");
-		var metadataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 
 		var typeDef = metadataImport.FindTypeDefByNameOrNull("System.Decimal", mdToken.Nil);
 		if (typeDef is null || typeDef.Value.IsNil) throw new InvalidOperationException("Could not find System.Decimal type definition");

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using Ardalis.GuardClauses;
-using ClrDebug;
+using ICorDebugSharp;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Compiler;
 using SharpDbg.Infrastructure.Debugger.Models;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
@@ -195,7 +195,7 @@ public partial class ManagedDebugger
 		if (_threads.TryGetValue(threadId, out var thread))
 		{
 			var frame = thread.ActiveFrame;
-			if (frame is not CorDebugILFrame ilFrame) throw new InvalidOperationException("Active frame is not an IL frame");
+			if (frame is not ICorDebugILFrame ilFrame) throw new InvalidOperationException("Active frame is not an IL frame");
 			if (_stepper is not null) throw new InvalidOperationException("A step operation is already in progress");
 
 			// Try async stepping first
@@ -377,7 +377,7 @@ public partial class ManagedDebugger
 
 				foreach (var (index, frame) in filterFrames.Index())
 				{
-					if (frame is CorDebugILFrame ilFrame)
+					if (frame is ICorDebugILFrame ilFrame)
 					{
 						var function = ilFrame.Function;
 
@@ -604,10 +604,10 @@ public partial class ManagedDebugger
 		var frameStackDepth = new FrameStackDepth(0);
 		var (friendlyTypeName, _, _, _) = await GetValueForCorDebugValueAsync(currentException, threadId, frameStackDepth);
 
-		var (_, hResult, _, _) = await GetValueForCorDebugValueAsync((await currentException.GetPropertyValue(_callbacks, EvalStatus, (CorDebugILFrame)thread.ActiveFrame, "HResult"))!, threadId, frameStackDepth);
-		var (_, source, _, _) = await GetValueForCorDebugValueAsync((await currentException.GetPropertyValue(_callbacks, EvalStatus, (CorDebugILFrame)thread.ActiveFrame, "Source"))!, threadId, frameStackDepth);
-		var (_, message, _, _) = await GetValueForCorDebugValueAsync((await currentException.GetPropertyValue(_callbacks, EvalStatus, (CorDebugILFrame)thread.ActiveFrame, "Message"))!, threadId, frameStackDepth);
-		var (_, stackTrace, _, _) = await GetValueForCorDebugValueAsync((await currentException.GetPropertyValue(_callbacks, EvalStatus, (CorDebugILFrame)thread.ActiveFrame, "StackTrace"))!, threadId, frameStackDepth);
+		var (_, hResult, _, _) = await GetValueForCorDebugValueAsync((await currentException.GetPropertyValue(_callbacks, EvalStatus, (ICorDebugILFrame)thread.ActiveFrame, "HResult"))!, threadId, frameStackDepth);
+		var (_, source, _, _) = await GetValueForCorDebugValueAsync((await currentException.GetPropertyValue(_callbacks, EvalStatus, (ICorDebugILFrame)thread.ActiveFrame, "Source"))!, threadId, frameStackDepth);
+		var (_, message, _, _) = await GetValueForCorDebugValueAsync((await currentException.GetPropertyValue(_callbacks, EvalStatus, (ICorDebugILFrame)thread.ActiveFrame, "Message"))!, threadId, frameStackDepth);
+		var (_, stackTrace, _, _) = await GetValueForCorDebugValueAsync((await currentException.GetPropertyValue(_callbacks, EvalStatus, (ICorDebugILFrame)thread.ActiveFrame, "StackTrace"))!, threadId, frameStackDepth);
 
 		var typeNameSpan = friendlyTypeName.AsSpan();
 		var lastDot = typeNameSpan.LastIndexOf('.');

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
@@ -439,7 +439,7 @@ public partial class ManagedDebugger
 		var localVariables = frame.LocalVariables;
 		var arguments = frame.Arguments;
 		var thread = _process!.Threads.Single(s => s.Id == threadId.Value);
-		var hasCurrentException = thread.TryGetCurrentException(out _) is HRESULT.S_OK;
+		var hasCurrentException = thread.TryGetCurrentException(out _) is Cor.S_OK;
 		if (localVariables.Length is 0 && arguments.Length is 0 && !hasCurrentException) return result;
 
 		// can this just be the same reference?
@@ -582,10 +582,10 @@ public partial class ManagedDebugger
 		}
 		else
 		{
-			if (_process is not null && _isAttached && _process?.TryIsRunning(out var isRunning) is HRESULT.S_OK && isRunning)
+			if (_process is not null && _isAttached && _process?.TryIsRunning(out var isRunning) is Cor.S_OK && isRunning)
 			{
 				var hResult = _process.TryStop(0);
-				if (hResult is not (HRESULT.S_OK or HRESULT.CORDBG_E_PROCESS_TERMINATED)) _logger?.Invoke($"Error stopping process during disconnect: {hResult}");
+				if (hResult is not (Cor.S_OK or Cor.CORDBG_E_PROCESS_TERMINATED)) _logger?.Invoke($"Error stopping process during disconnect: {hResult}");
 			}
 			Dispose();
 		}
@@ -595,7 +595,7 @@ public partial class ManagedDebugger
 	{
 		_logger?.Invoke($"ExceptionInfo for thread {threadId.Value}");
 		var thread = _process!.GetThread(threadId.Value);
-		if (thread.TryGetCurrentException(out var currentException) is not HRESULT.S_OK)
+		if (thread.TryGetCurrentException(out var currentException) is not Cor.S_OK)
 		{
 			_logger?.Invoke("No current exception");
 			throw new InvalidOperationException("No current exception on thread");

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
@@ -494,11 +494,11 @@ public partial class ManagedDebugger
 				}
 				var unwrappedDebugValue = variablesReference.ObjectValue!.UnwrapDebugValue();
 
-				if (unwrappedDebugValue is CorDebugArrayValue arrayValue)
+				if (unwrappedDebugValue is ICorDebugArrayValue arrayValue)
 				{
 					await AddArrayElements(arrayValue, variablesReference.ThreadId, variablesReference.FrameStackDepth, result);
 				}
-				else if (unwrappedDebugValue is CorDebugObjectValue objectValue)
+				else if (unwrappedDebugValue is ICorDebugObjectValue objectValue)
 				{
 					await AddMembersAndStaticPseudoVariable(variablesReference.ObjectValue!, objectValue.ExactType, variablesReference.ThreadId, variablesReference.FrameStackDepth, result);
 				}

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
@@ -33,7 +33,7 @@ public partial class ManagedDebugger
 	/// <summary>
 	/// Actually perform the launch using DbgShim APIs
 	/// </summary>
-	private void PerformLaunch()
+	private async Task PerformLaunch()
 	{
 		if (_pendingLaunchInfo is null)
 		{
@@ -43,9 +43,6 @@ public partial class ManagedDebugger
 
 		var launchInfo = _pendingLaunchInfo;
 		_pendingLaunchInfo = null;
-
-		// Initialize DbgShim
-		var dbgshim = new DbgShim(NativeLibrary.Load("dbgshim", typeof(ManagedDebugger).Assembly, null));
 
 		var processStartInfo = new ProcessStartInfo
 		{
@@ -76,7 +73,7 @@ public partial class ManagedDebugger
 
 		_logger?.Invoke($"Process created suspended with PID: {processId}");
 
-		_corDebug = ClrDebugExtensions.Automatic(dbgshim, processId, true);
+		_corDebug = await ClrDebugExtensions.Automatic(processId, true);
 		_corDebug.Initialize();
 		_corDebug.SetManagedHandler(_callbacks);
 
@@ -140,7 +137,7 @@ public partial class ManagedDebugger
 		}
 		else if (_pendingLaunchInfo is not null) // If we have a pending launch, perform it
 		{
-			PerformLaunch();
+			await PerformLaunch();
 		}
 		else if (_pendingRemoteAttachInfo is not null)
 		{

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
@@ -284,7 +284,7 @@ public partial class ManagedDebugger
 			var isStatic = fieldProps.pdwAttr.IsFdStatic();
 			var isLiteral = fieldProps.pdwAttr.IsFdLiteral();
 			var debuggerBrowsableRootHidden = false;
-			var hasDebuggerBrowsableAttribute = metadataImport.TryGetCustomAttributeByName(mdFieldDef, "System.Diagnostics.DebuggerBrowsableAttribute", out var debuggerBrowsableAttribute) is HRESULT.S_OK;
+			var hasDebuggerBrowsableAttribute = metadataImport.TryGetCustomAttributeByName(mdFieldDef, "System.Diagnostics.DebuggerBrowsableAttribute", out var debuggerBrowsableAttribute) is Cor.S_OK;
 			if (hasDebuggerBrowsableAttribute)
 			{
 				// https://github.com/Samsung/netcoredbg/blob/6476bc00c2beaab9255c750235a68de3a3d0cfae/src/debugger/evaluator.cpp#L913
@@ -353,7 +353,7 @@ public partial class ManagedDebugger
 			var isStatic = getterAttr.IsMdStatic();
 
 			var debuggerBrowsableRootHidden = false;
-			var hasDebuggerBrowsableAttribute = metadataImport.TryGetCustomAttributeByName(mdProperty, "System.Diagnostics.DebuggerBrowsableAttribute", out var debuggerBrowsableAttribute) is HRESULT.S_OK;
+			var hasDebuggerBrowsableAttribute = metadataImport.TryGetCustomAttributeByName(mdProperty, "System.Diagnostics.DebuggerBrowsableAttribute", out var debuggerBrowsableAttribute) is Cor.S_OK;
 			if (hasDebuggerBrowsableAttribute)
 			{
 				// https://github.com/Samsung/netcoredbg/blob/6476bc00c2beaab9255c750235a68de3a3d0cfae/src/debugger/evaluator.cpp#L913

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
@@ -50,7 +50,7 @@ public partial class ManagedDebugger
 
 		// Follow the DisplayClassLocalOrField link to the parent closure, if any
 		var objectValue = closureValue.UnwrapDebugValueToObject();
-		var metadataImport = objectValue.Class.Module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = objectValue.Class.Module.GetMetaDataInterface<IMetaDataImport>();
 		var fields = metadataImport.EnumFields(objectValue.Class.Token);
 		foreach (var field in fields)
 		{
@@ -69,7 +69,7 @@ public partial class ManagedDebugger
 	{
 		var corDebugIlFrame = GetFrameForThreadIdAndStackDepth(threadId, stackDepth);
 		if (corDebugIlFrame.Arguments.Length is 0) return null;
-		var metadataImport = module.Module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = module.Module.GetMetaDataInterface<IMetaDataImport>();
 
 		// localsScope.Frame.Arguments includes the implicit "this" parameter for instance methods,
 		// but GetParamForMethodIndex does NOT include it - it is named by convention
@@ -217,7 +217,7 @@ public partial class ManagedDebugger
 		var corDebugClass = corDebugType.Class;
 		var module = corDebugClass.Module;
 		var mdTypeDef = corDebugClass.Token;
-		var metadataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		var mdFieldDefs = includeNonPublicMembers ? metadataImport.EnumFields(mdTypeDef) : metadataImport.EnumFields(mdTypeDef).AsValueEnumerable().Where(s => s.IsPublic(metadataImport)).ToArray();
 		var mdProperties = includeNonPublicMembers ? metadataImport.EnumProperties(mdTypeDef) : metadataImport.EnumProperties(mdTypeDef).AsValueEnumerable().Where(s => s.IsPublic(metadataImport)).ToArray();
 		var staticFieldDefs = mdFieldDefs.AsValueEnumerable().Where(s => s.IsStatic(metadataImport)).ToArray();
@@ -246,7 +246,7 @@ public partial class ManagedDebugger
 		var corDebugClass = corDebugType.Class;
 		var module = corDebugClass.Module;
 		var mdTypeDef = corDebugClass.Token;
-		var metadataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		var staticFieldDefs = metadataImport.EnumFields(mdTypeDef).AsValueEnumerable().Where(s => s.IsStatic(metadataImport)).ToArray();
 		var staticProperties = metadataImport.EnumProperties(mdTypeDef).AsValueEnumerable().Where(s => s.IsStatic(metadataImport)).ToArray();
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
@@ -9,7 +9,7 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public partial class ManagedDebugger
 {
-	private async Task AddLocalVariables(ModuleInfo module, CorDebugFunction corDebugFunction, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue? classContainingHoistedLocalsValue)
+	private async Task AddLocalVariables(ModuleInfo module, ICorDebugFunction corDebugFunction, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue? classContainingHoistedLocalsValue)
 	{
 		if (classContainingHoistedLocalsValue is not null)
 		{
@@ -65,7 +65,7 @@ public partial class ManagedDebugger
 	}
 
 	/// Returns classContainingHoistedLocalsValue if applicable
-	private async Task<ICorDebugValue?> AddArguments(ModuleInfo module, CorDebugFunction corDebugFunction, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth)
+	private async Task<ICorDebugValue?> AddArguments(ModuleInfo module, ICorDebugFunction corDebugFunction, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth)
 	{
 		var corDebugIlFrame = GetFrameForThreadIdAndStackDepth(threadId, stackDepth);
 		if (corDebugIlFrame.Arguments.Length is 0) return null;
@@ -160,14 +160,14 @@ public partial class ManagedDebugger
 			if (arrayValue.Count is 0) return 0;
 			return GenerateUniqueVariableReference(corDebugValue, threadId, stackDepth, debuggerProxyInstance);
 		}
-		else if (unwrappedDebugValue is CorDebugObjectValue objectValue)
+		else if (unwrappedDebugValue is ICorDebugObjectValue objectValue)
 		{
 			var isNullableStruct = friendlyTypeName.EndsWith('?');
 			if (isNullableStruct)
 			{
 				var underlyingValueOrNull = GetUnderlyingValueOrNullFromNullableStruct(objectValue);
 				if (underlyingValueOrNull is null) return 0;
-				if (underlyingValueOrNull is not CorDebugObjectValue objValue) return 0; // underlying value is primitive
+				if (underlyingValueOrNull is not ICorDebugObjectValue objValue) return 0; // underlying value is primitive
 				objectValue = objValue;
 			}
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using ClrDebug;
+using ICorDebugSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using SharpDbg.Infrastructure.Debugger.Models.Response;
 using SharpDbg.Infrastructure.Debugger.PresentationHintModels;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
@@ -9,7 +9,7 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public partial class ManagedDebugger
 {
-	private async Task AddLocalVariables(ModuleInfo module, CorDebugFunction corDebugFunction, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth, CorDebugValue? classContainingHoistedLocalsValue)
+	private async Task AddLocalVariables(ModuleInfo module, CorDebugFunction corDebugFunction, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue? classContainingHoistedLocalsValue)
 	{
 		if (classContainingHoistedLocalsValue is not null)
 		{
@@ -44,7 +44,7 @@ public partial class ManagedDebugger
 	/// Walks the compiler-generated closure chain starting at <paramref name="closureValue"/>,
 	/// calling AddMembers on each closure class. Parent closures are linked via a field of
 	/// kind <see cref="GeneratedNameKind.DisplayClassLocalOrField"/> (e.g. "&lt;&gt;8__1").
-	private async Task AddClosureChainMembers(CorDebugValue closureValue, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result)
+	private async Task AddClosureChainMembers(ICorDebugValue closureValue, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result)
 	{
 		await AddMembers(closureValue, closureValue.ExactType, threadId, stackDepth, result);
 
@@ -57,7 +57,7 @@ public partial class ManagedDebugger
 			var fieldProps = metadataImport.GetFieldProps(field);
 			if (GeneratedNameParser.GetKind(fieldProps.szField) is GeneratedNameKind.DisplayClassLocalOrField)
 			{
-				var parentClosureValue = objectValue.GetFieldValue(objectValue.Class.Raw, field);
+				var parentClosureValue = objectValue.GetFieldValue(objectValue.Class, field);
 				await AddClosureChainMembers(parentClosureValue, threadId, stackDepth, result);
 				break; // only one parent link per closure class
 			}
@@ -65,7 +65,7 @@ public partial class ManagedDebugger
 	}
 
 	/// Returns classContainingHoistedLocalsValue if applicable
-	private async Task<CorDebugValue?> AddArguments(ModuleInfo module, CorDebugFunction corDebugFunction, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth)
+	private async Task<ICorDebugValue?> AddArguments(ModuleInfo module, CorDebugFunction corDebugFunction, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth)
 	{
 		var corDebugIlFrame = GetFrameForThreadIdAndStackDepth(threadId, stackDepth);
 		if (corDebugIlFrame.Arguments.Length is 0) return null;
@@ -76,7 +76,7 @@ public partial class ManagedDebugger
 		// so we need to check the method attributes to see if it's static or instance, to conditionally handle "this"
 		var methodProps = metadataImport!.GetMethodProps(corDebugFunction.Token);
 		var isStatic = methodProps.pdwAttr.IsMdStatic();
-		CorDebugValue? classContainingHoistedLocalsValue = null;
+		ICorDebugValue? classContainingHoistedLocalsValue = null;
 		if (isStatic is false)
 		{
 			var methodName = methodProps.szMethod;
@@ -152,10 +152,10 @@ public partial class ManagedDebugger
 		}
 	}
 
-	private int GetVariablesReference(CorDebugValue corDebugValue, string friendlyTypeName, ThreadId threadId, FrameStackDepth stackDepth, CorDebugValue? debuggerProxyInstance)
+	private int GetVariablesReference(ICorDebugValue corDebugValue, string friendlyTypeName, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue? debuggerProxyInstance)
 	{
 		var unwrappedDebugValue = corDebugValue.UnwrapDebugValue();
-		if (unwrappedDebugValue is CorDebugArrayValue arrayValue)
+		if (unwrappedDebugValue is ICorDebugArrayValue arrayValue)
 		{
 			if (arrayValue.Count is 0) return 0;
 			return GenerateUniqueVariableReference(corDebugValue, threadId, stackDepth, debuggerProxyInstance);
@@ -186,14 +186,14 @@ public partial class ManagedDebugger
 		return 0;
 	}
 
-	private int GenerateUniqueVariableReference(CorDebugValue value, ThreadId threadId, FrameStackDepth stackDepth, CorDebugValue? debuggerProxyInstance)
+	private int GenerateUniqueVariableReference(ICorDebugValue value, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue? debuggerProxyInstance)
 	{
 		var variablesReference = new VariablesReference(StoredReferenceKind.StackVariable, value, threadId, stackDepth, debuggerProxyInstance);
 		var reference = _variableManager.CreateReference(variablesReference);
 		return reference;
 	}
 
-	private async Task AddMembersAndStaticPseudoVariable(CorDebugValue corDebugValue, CorDebugType corDebugType, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result, bool includeNonPublicMembers = true)
+	private async Task AddMembersAndStaticPseudoVariable(ICorDebugValue corDebugValue, ICorDebugType corDebugType, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result, bool includeNonPublicMembers = true)
 	{
 		var requiresStaticPseudoVariable = await AddMembers(corDebugValue, corDebugType, threadId, stackDepth, result, includeNonPublicMembers);
 		if (requiresStaticPseudoVariable)
@@ -211,7 +211,7 @@ public partial class ManagedDebugger
 	}
 
 	/// Returns a bool indicating if a Static Members pseudo variable is required
-	private async Task<bool> AddMembers(CorDebugValue corDebugValue, CorDebugType corDebugType, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result, bool includeNonPublicMembers = true)
+	private async Task<bool> AddMembers(ICorDebugValue corDebugValue, ICorDebugType corDebugType, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result, bool includeNonPublicMembers = true)
 	{
 		var hasStaticMembers = false;
 		var corDebugClass = corDebugType.Class;
@@ -241,7 +241,7 @@ public partial class ManagedDebugger
 		return hasStaticMembers | await AddMembers(corDebugValue, baseType, threadId, stackDepth, result);
 	}
 
-	private async Task AddStaticMembers(CorDebugValue corDebugValue, CorDebugType corDebugType, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result)
+	private async Task AddStaticMembers(ICorDebugValue corDebugValue, ICorDebugType corDebugType, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result)
 	{
 		var corDebugClass = corDebugType.Class;
 		var module = corDebugClass.Module;
@@ -262,7 +262,7 @@ public partial class ManagedDebugger
 		await AddStaticMembers(corDebugValue, baseType, threadId, stackDepth, result);
 	}
 
-	private async Task AddFields(mdFieldDef[] mdFieldDefs, MetaDataImport metadataImport, CorDebugClass corDebugClass, CorDebugValue corDebugValue, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth)
+	private async Task AddFields(mdFieldDef[] mdFieldDefs, IMetaDataImport metadataImport, ICorDebugClass corDebugClass, ICorDebugValue corDebugValue, List<VariableInfo> result, ThreadId threadId, FrameStackDepth stackDepth)
 	{
 		foreach (var mdFieldDef in mdFieldDefs)
 		{
@@ -307,11 +307,11 @@ public partial class ManagedDebugger
 			}
 
 			var objectValue = corDebugValue.UnwrapDebugValueToObject();
-			var fieldCorDebugValue = isStatic ? corDebugClass.GetStaticFieldValue(mdFieldDef, GetFrameForThreadIdAndStackDepth(threadId, stackDepth).Raw) : objectValue.GetFieldValue(corDebugClass.Raw, mdFieldDef);
+			var fieldCorDebugValue = isStatic ? corDebugClass.GetStaticFieldValue(mdFieldDef, GetFrameForThreadIdAndStackDepth(threadId, stackDepth)) : objectValue.GetFieldValue(corDebugClass, mdFieldDef);
 			if (debuggerBrowsableRootHidden)
 			{
 				var unwrappedDebugValue = fieldCorDebugValue.UnwrapDebugValue();
-				if (unwrappedDebugValue is CorDebugArrayValue arrayValue)
+				if (unwrappedDebugValue is ICorDebugArrayValue arrayValue)
 				{
 					await AddArrayElements(arrayValue, threadId, stackDepth, result);
 					continue;
@@ -332,7 +332,7 @@ public partial class ManagedDebugger
 	}
 
 	internal class EvalException(string message) : Exception(message);
-	private async Task AddProperties(mdProperty[] mdProperties, MetaDataImport metadataImport, CorDebugClass corDebugClass, ThreadId threadId, FrameStackDepth stackDepth, CorDebugValue corDebugValue, List<VariableInfo> result)
+	private async Task AddProperties(mdProperty[] mdProperties, IMetaDataImport metadataImport, ICorDebugClass corDebugClass, ThreadId threadId, FrameStackDepth stackDepth, ICorDebugValue corDebugValue, List<VariableInfo> result)
 	{
 		foreach (var mdProperty in mdProperties)
 		{
@@ -369,18 +369,17 @@ public partial class ManagedDebugger
 			var parameterizedContainingType = corDebugValue.ExactType;
 
 			var typeParameterTypes = parameterizedContainingType.TypeParameters;
-			var typeParameterArgs = typeParameterTypes.Select(t => t.Raw).ToArray();
 
 			// For instance properties, pass the object; for static, pass nothing
-			ICorDebugValue[] corDebugValues = isStatic ? [] : [corDebugValue!.Raw];
+			ICorDebugValue[] corDebugValues = isStatic ? [] : [corDebugValue];
 
-			var returnValue = await eval.CallParameterizedFunctionAsync(_callbacks, EvalStatus, getMethod, typeParameterTypes.Length, typeParameterArgs, corDebugValues.Length, corDebugValues);
+			var returnValue = await eval.CallParameterizedFunctionAsync(_callbacks, EvalStatus, getMethod, typeParameterTypes.Length, typeParameterTypes, corDebugValues.Length, corDebugValues);
 
 			if (returnValue is null) continue;
 			if (debuggerBrowsableRootHidden)
 			{
 				var unwrappedDebugValue = returnValue.UnwrapDebugValue();
-				if (unwrappedDebugValue is CorDebugArrayValue arrayValue)
+				if (unwrappedDebugValue is ICorDebugArrayValue arrayValue)
 				{
 					await AddArrayElements(arrayValue, threadId, stackDepth, result);
 					continue;
@@ -400,14 +399,14 @@ public partial class ManagedDebugger
 		}
 	}
 
-	private async Task AddArrayElements(CorDebugArrayValue arrayValue, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result)
+	private async Task AddArrayElements(ICorDebugArrayValue arrayValue, ThreadId threadId, FrameStackDepth stackDepth, List<VariableInfo> result)
 	{
 		var rank = arrayValue.Rank;
 		if (rank > 1) throw new NotImplementedException("Multidimensional arrays not yet supported");
 		var itemCount = arrayValue.Count;
 
 		// Get the elements first, as the CorDebugArrayValue arrayValue may get neutered during 'await GetValueForCorDebugValueAsync' below, if any evals are required
-		var elements = ValueEnumerable.Range(0, itemCount).Select(i => arrayValue.GetElement(1, [i])).ToArray();
+		var elements = ValueEnumerable.Range(0, itemCount).Select(i => arrayValue.GetElement(1, [checked((uint)i)])).ToArray();
 		foreach (var (i, element) in elements.Index())
 		{
 			var (friendlyTypeName, value, debuggerProxyInstance, resultIsError) = await GetValueForCorDebugValueAsync(element, threadId, stackDepth);

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
@@ -284,11 +284,11 @@ public partial class ManagedDebugger
 			var isStatic = fieldProps.pdwAttr.IsFdStatic();
 			var isLiteral = fieldProps.pdwAttr.IsFdLiteral();
 			var debuggerBrowsableRootHidden = false;
-			var hasDebuggerBrowsableAttribute = metadataImport.TryGetCustomAttributeByName(mdFieldDef, "System.Diagnostics.DebuggerBrowsableAttribute", out var debuggerBrowsableAttribute) is Cor.S_OK;
+			var hasDebuggerBrowsableAttribute = metadataImport.TryGetCustomAttributeByName(mdFieldDef, "System.Diagnostics.DebuggerBrowsableAttribute", out var debuggerBrowsableAttributePointer, out var debuggerBrowsableAttributeSize) is Cor.S_OK;
 			if (hasDebuggerBrowsableAttribute)
 			{
 				// https://github.com/Samsung/netcoredbg/blob/6476bc00c2beaab9255c750235a68de3a3d0cfae/src/debugger/evaluator.cpp#L913
-				var debuggerBrowsableState = (DebuggerBrowsableState)GetDebuggerBrowsableCustomAttributeResultInt(debuggerBrowsableAttribute);
+				var debuggerBrowsableState = (DebuggerBrowsableState)GetDebuggerBrowsableCustomAttributeResultInt(debuggerBrowsableAttributePointer, debuggerBrowsableAttributeSize);
 				if (debuggerBrowsableState == DebuggerBrowsableState.Never) continue; // I may not end up doing this, as it would be ideal to still be able to hover the variable in the editor and see the value
 				if (debuggerBrowsableState == DebuggerBrowsableState.RootHidden) debuggerBrowsableRootHidden = true;
 			}
@@ -353,11 +353,11 @@ public partial class ManagedDebugger
 			var isStatic = getterAttr.IsMdStatic();
 
 			var debuggerBrowsableRootHidden = false;
-			var hasDebuggerBrowsableAttribute = metadataImport.TryGetCustomAttributeByName(mdProperty, "System.Diagnostics.DebuggerBrowsableAttribute", out var debuggerBrowsableAttribute) is Cor.S_OK;
+			var hasDebuggerBrowsableAttribute = metadataImport.TryGetCustomAttributeByName(mdProperty, "System.Diagnostics.DebuggerBrowsableAttribute", out var debuggerBrowsableAttributePointer, out var debuggerBrowsableAttributeSize) is Cor.S_OK;
 			if (hasDebuggerBrowsableAttribute)
 			{
 				// https://github.com/Samsung/netcoredbg/blob/6476bc00c2beaab9255c750235a68de3a3d0cfae/src/debugger/evaluator.cpp#L913
-				var debuggerBrowsableState = (DebuggerBrowsableState)GetDebuggerBrowsableCustomAttributeResultInt(debuggerBrowsableAttribute);
+				var debuggerBrowsableState = (DebuggerBrowsableState)GetDebuggerBrowsableCustomAttributeResultInt(debuggerBrowsableAttributePointer, debuggerBrowsableAttributeSize);
 				if (debuggerBrowsableState == DebuggerBrowsableState.Never) continue; // I may not end up doing this, as it would be ideal to still be able to hover the variable in the editor and see the value
 				if (debuggerBrowsableState == DebuggerBrowsableState.RootHidden) debuggerBrowsableRootHidden = true;
 			}

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo.cs
@@ -173,12 +173,12 @@ public partial class ManagedDebugger
 
 			var type = objectValue.Type;
 			// Strings are objects but typically displayed as primitives
-			if (type is CorElementType.String) return 0;
+			if (type is CorElementType.STRING) return 0;
 			// Decimal is a struct but should be treated as a primitive
 			if (friendlyTypeName is "decimal" or "decimal?") return 0;
-			// a boxed primitive is CorElementType.ValueType but should be displayed as a primitive. They can never be nullable.
+			// a boxed primitive is CorElementType.VALUETYPE but should be displayed as a primitive. They can never be nullable.
 			if (friendlyTypeName is "bool" or "byte" or "sbyte" or "char" or "short" or "ushort" or "int" or "uint" or "long" or "ulong" or "float" or "double" or "nint" or "nuint") return 0;
-			if (type is CorElementType.Class or CorElementType.ValueType or CorElementType.SZArray or CorElementType.Array)
+			if (type is CorElementType.CLASS or CorElementType.VALUETYPE or CorElementType.SZARRAY or CorElementType.ARRAY)
 			{
 				return GenerateUniqueVariableReference(corDebugValue, threadId, stackDepth, debuggerProxyInstance);
 			}

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo_ProxyField.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo_ProxyField.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace SharpDbg.Infrastructure.Debugger;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo_ProxyField.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo_ProxyField.cs
@@ -5,7 +5,7 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public partial class ManagedDebugger
 {
-	private static CorDebugValue? GetAsyncOrLambdaProxyFieldValue(CorDebugValue compilerGeneratedClassValue, MetaDataImport metadataImport)
+	private static ICorDebugValue? GetAsyncOrLambdaProxyFieldValue(ICorDebugValue compilerGeneratedClassValue, IMetaDataImport metadataImport)
 	{
 		var objectValue = compilerGeneratedClassValue.UnwrapDebugValueToObject();
 		var fields = metadataImport.EnumFields(objectValue.Class.Token);
@@ -16,13 +16,13 @@ public partial class ManagedDebugger
 			var generatedNameKind = GeneratedNameParser.GetKind(fieldName);
 			if (generatedNameKind is GeneratedNameKind.ThisProxyField)
 			{
-				var fieldCorDebugValue = objectValue.GetFieldValue(objectValue.Class.Raw, field);
+				var fieldCorDebugValue = objectValue.GetFieldValue(objectValue.Class, field);
 				return fieldCorDebugValue;
 			}
 			else if (generatedNameKind is GeneratedNameKind.DisplayClassLocalOrField)
 			{
 				// This field points to a parent closure class - follow the chain to find 'this'
-				var parentClosureValue = objectValue.GetFieldValue(objectValue.Class.Raw, field);
+				var parentClosureValue = objectValue.GetFieldValue(objectValue.Class, field);
 				var parentObjectValue = parentClosureValue.UnwrapDebugValueToObject();
 				var parentMetadataImport = parentObjectValue.Class.Module.GetMetaDataInterface<IMetaDataImport>();
 				return GetAsyncOrLambdaProxyFieldValue(parentClosureValue, parentMetadataImport);

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo_ProxyField.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableInfo_ProxyField.cs
@@ -24,7 +24,7 @@ public partial class ManagedDebugger
 				// This field points to a parent closure class - follow the chain to find 'this'
 				var parentClosureValue = objectValue.GetFieldValue(objectValue.Class.Raw, field);
 				var parentObjectValue = parentClosureValue.UnwrapDebugValueToObject();
-				var parentMetadataImport = parentObjectValue.Class.Module.GetMetaDataInterface().MetaDataImport;
+				var parentMetadataImport = parentObjectValue.Class.Module.GetMetaDataInterface<IMetaDataImport>();
 				return GetAsyncOrLambdaProxyFieldValue(parentClosureValue, parentMetadataImport);
 			}
 		}

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
@@ -45,8 +45,8 @@ public partial class ManagedDebugger
 			var debugProxyTypeConstructorMethodDef = metadataImport.FindMethod(debugProxyCorDebugClass.Token, ".ctor", 0, 0);
 			//var debugProxyTypeCtorMethodProps = metadataImport.GetMethodProps(debugProxyTypeConstructorMethodDef);
 			var corDebugFunction = module.GetFunctionFromToken(debugProxyTypeConstructorMethodDef);
-			ICorDebugValue[] evalArgs = [corDebugValue.Raw];
-			var typeParameterArgs = corDebugValue.ExactType.TypeParameters.Select(t => t.Raw).ToArray();
+			ICorDebugValue[] evalArgs = [corDebugValue];
+			var typeParameterArgs = corDebugValue.ExactType.TypeParameters;
 			proxyInstance = await eval.NewParameterizedObjectAsync(_callbacks, EvalStatus, corDebugFunction, typeParameterArgs.Length, typeParameterArgs, evalArgs.Length, evalArgs);
 			ArgumentNullException.ThrowIfNull(proxyInstance);
 		}
@@ -187,10 +187,10 @@ public partial class ManagedDebugger
 		var hasValueFieldDef = metaDataImport.FindField(corDebugObjectValue.Class.Token, "hasValue", 0, 0);
 		var valueFieldDef = metaDataImport.FindField(corDebugObjectValue.Class.Token, "value", 0, 0);
 
-		var hasValueDebugObjectValue = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class.Raw, hasValueFieldDef);
+		var hasValueDebugObjectValue = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class, hasValueFieldDef);
 		var hasValueValue = GetValueForCorDebugValue(hasValueDebugObjectValue);
 		if (hasValueValue.Value is "false") return null;
-		var valueValue = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class.Raw, valueFieldDef);
+		var valueValue = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class, valueFieldDef);
 		return valueValue;
 	}
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
@@ -12,7 +12,7 @@ namespace SharpDbg.Infrastructure.Debugger;
 public readonly record struct CorDebugValueValueResult(string FriendlyTypeName, string Value, bool ValueRequiresDebuggerDisplayEval, string? DebuggerProxyTypeName);
 public partial class ManagedDebugger
 {
-	public async Task<(string friendlyTypeName, string value, CorDebugValue? debuggerProxyInstance, bool resultIsError)> GetValueForCorDebugValueAsync(CorDebugValue corDebugValue, ThreadId threadId, FrameStackDepth frameStackDepth)
+	public async Task<(string friendlyTypeName, string value, ICorDebugValue? debuggerProxyInstance, bool resultIsError)> GetValueForCorDebugValueAsync(ICorDebugValue corDebugValue, ThreadId threadId, FrameStackDepth frameStackDepth)
 	{
 		Guard.Against.Null(corDebugValue);
 		var (friendlyTypeName, value, valueRequiresDebuggerDisplayEval, debuggerProxyTypeName) = GetValueForCorDebugValue(corDebugValue);
@@ -30,7 +30,7 @@ public partial class ManagedDebugger
 			}
 			(_, value, _, _) = GetValueForCorDebugValue(result.Value!);
 		}
-		CorDebugValue? proxyInstance = null;
+		ICorDebugValue? proxyInstance = null;
 		if (debuggerProxyTypeName is not null)
 		{
 			var thread = _process!.GetThread(threadId.Value);
@@ -53,33 +53,33 @@ public partial class ManagedDebugger
 		return (friendlyTypeName, value, proxyInstance, false);
 	}
 
-	private static CorDebugValueValueResult GetValueForCorDebugValue(CorDebugValue corDebugValue)
+	private static CorDebugValueValueResult GetValueForCorDebugValue(ICorDebugValue corDebugValue)
 	{
 		var (friendlyTypeName, value, valueRequiresDebuggerDisplayEval, debuggerTypeProxy) = corDebugValue switch
 		{
-			CorDebugBoxValue corDebugBoxValue => GetCorDebugBoxValue_Value_AsString(corDebugBoxValue),
-			CorDebugArrayValue corDebugArrayValue => Get_CorDebugArrayValue_AsString(corDebugArrayValue),
-			CorDebugStringValue stringValue => Get_CorDebugStringValue_AsString(stringValue),
+			ICorDebugBoxValue corDebugBoxValue => GetCorDebugBoxValue_Value_AsString(corDebugBoxValue),
+			ICorDebugArrayValue corDebugArrayValue => Get_CorDebugArrayValue_AsString(corDebugArrayValue),
+			ICorDebugStringValue stringValue => Get_CorDebugStringValue_AsString(stringValue),
 
-			CorDebugContext corDebugContext => throw new NotImplementedException(),
-			CorDebugObjectValue corDebugObjectValue => GetCorDebugObjectValue_Value_AsString(corDebugObjectValue),
+			ICorDebugContext corDebugContext => throw new NotImplementedException(),
+			ICorDebugObjectValue corDebugObjectValue => GetCorDebugObjectValue_Value_AsString(corDebugObjectValue),
 			//CorDebugHandleValue corDebugHandleValue => throw new NotImplementedException(), // handled by CorDebugReferenceValue
-			CorDebugReferenceValue corDebugReferenceValue => GetCorDebugReferenceValue_Value_AsString(corDebugReferenceValue),
+			ICorDebugReferenceValue corDebugReferenceValue => GetCorDebugReferenceValue_Value_AsString(corDebugReferenceValue),
 
-			CorDebugHeapValue corDebugHeapValue => throw new NotImplementedException(),
-			CorDebugGenericValue corDebugGenericValue => GetCorDebugGenericValue_Value_AsString(corDebugGenericValue),  // This should be already handled by the above classes, so we should never get here
+			ICorDebugHeapValue corDebugHeapValue => throw new NotImplementedException(),
+			ICorDebugGenericValue corDebugGenericValue => GetCorDebugGenericValue_Value_AsString(corDebugGenericValue),  // This should be already handled by the above classes, so we should never get here
 			_ => throw new ArgumentOutOfRangeException(nameof(corDebugValue))
 		};
 		return new(friendlyTypeName, value, valueRequiresDebuggerDisplayEval, debuggerTypeProxy);
 	}
 
-	private static CorDebugValueValueResult Get_CorDebugStringValue_AsString(CorDebugStringValue corDebugStringValue)
+	private static CorDebugValueValueResult Get_CorDebugStringValue_AsString(ICorDebugStringValue corDebugStringValue)
 	{
-		var text = corDebugStringValue.GetStringWithoutBug(corDebugStringValue.Length + 1);
+		var text = corDebugStringValue.String;
 		return new("string", text, false, null);
 	}
 
-	public static CorDebugValueValueResult Get_CorDebugArrayValue_AsString(CorDebugArrayValue corDebugArrayValue)
+	public static CorDebugValueValueResult Get_CorDebugArrayValue_AsString(ICorDebugArrayValue corDebugArrayValue)
 	{
 		var typeName = GetCorDebugTypeFriendlyName(corDebugArrayValue.ExactType);
 		var typeNameSpan = typeName.AsSpan();
@@ -89,14 +89,14 @@ public partial class ManagedDebugger
 		return new(typeName, value, false, null);
 	}
 
-	public static CorDebugValueValueResult GetCorDebugBoxValue_Value_AsString(CorDebugBoxValue corDebugBoxValue)
+	public static CorDebugValueValueResult GetCorDebugBoxValue_Value_AsString(ICorDebugBoxValue corDebugBoxValue)
 	{
 		var unboxedValue = corDebugBoxValue.Object;
 		var value = GetValueForCorDebugValue(unboxedValue);
 		return value;
 	}
 
-	public static CorDebugValueValueResult GetCorDebugObjectValue_Value_AsString(CorDebugObjectValue corDebugObjectValue)
+	public static CorDebugValueValueResult GetCorDebugObjectValue_Value_AsString(ICorDebugObjectValue corDebugObjectValue)
 	{
 		var module = corDebugObjectValue.Class.Module;
 		var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
@@ -104,7 +104,7 @@ public partial class ManagedDebugger
 		if (baseTypeName is "System.Enum")
 		{
 			var valueFieldDef = metaDataImport.FindField(corDebugObjectValue.Class.Token, "value__", 0, 0);
-			var valueField = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class.Raw, valueFieldDef);
+			var valueField = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class, valueFieldDef);
 			var value = GetValueForCorDebugValue(valueField);
 
 			var enumDisplayValue = GetEnumDisplayValue(metaDataImport, corDebugObjectValue, value.Value);
@@ -157,7 +157,7 @@ public partial class ManagedDebugger
 
 	/// Returns true if <paramref name="corDebugType"/> or any of its base types (up to but not
 	/// including System.Object / System.ValueType) declares a no-arg "ToString" method directly on itself.
-	private static bool TypeOverridesToString(CorDebugType corDebugType)
+	private static bool TypeOverridesToString(ICorDebugType corDebugType)
 	{
 		var type = corDebugType;
 		while (type is not null)
@@ -180,7 +180,7 @@ public partial class ManagedDebugger
 		return false;
 	}
 
-	private static CorDebugValue? GetUnderlyingValueOrNullFromNullableStruct(CorDebugObjectValue corDebugObjectValue)
+	private static ICorDebugValue? GetUnderlyingValueOrNullFromNullableStruct(ICorDebugObjectValue corDebugObjectValue)
 	{
 		var module = corDebugObjectValue.Class.Module;
 		var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
@@ -194,7 +194,7 @@ public partial class ManagedDebugger
 		return valueValue;
 	}
 
-	public static CorDebugValueValueResult GetCorDebugReferenceValue_Value_AsString(CorDebugReferenceValue corDebugReferenceValue)
+	public static CorDebugValueValueResult GetCorDebugReferenceValue_Value_AsString(ICorDebugReferenceValue corDebugReferenceValue)
 	{
 		if (corDebugReferenceValue.IsNull)
 		{
@@ -207,16 +207,16 @@ public partial class ManagedDebugger
 		return value;
 	}
 
-	internal static string GetCorDebugTypeFriendlyName(CorDebugType corDebugType)
+	internal static string GetCorDebugTypeFriendlyName(ICorDebugType corDebugType)
 	{
 		var primitiveName = GetFriendlyTypeName(corDebugType.Type);
 		if (primitiveName is not null) return primitiveName;
-		if (corDebugType.Type is CorElementType.SZArray)
+		if (corDebugType.Type is CorElementType.SZARRAY)
 		{
 			var elementName = GetCorDebugTypeFriendlyName(corDebugType.FirstTypeParameter);
 			return $"{elementName}[]";
 		}
-		if (corDebugType.Type is CorElementType.Array)
+		if (corDebugType.Type is CorElementType.ARRAY)
 		{
 			var elementName = GetCorDebugTypeFriendlyName(corDebugType.FirstTypeParameter);
 			return $"{elementName}[{new string(',', corDebugType.Rank - 1)}]";
@@ -230,7 +230,7 @@ public partial class ManagedDebugger
 		return name;
 	}
 
-	private static string GetCorDebugTypeFriendlyNameInternal(CorDebugClass corDebugClass, List<CorDebugType> typeParameterTypes)
+	private static string GetCorDebugTypeFriendlyNameInternal(ICorDebugClass corDebugClass, List<ICorDebugType> typeParameterTypes)
 	{
 		var module = corDebugClass.Module;
 		var token = corDebugClass.Token;
@@ -304,7 +304,7 @@ public partial class ManagedDebugger
 		return className;
 	}
 
-	public static CorDebugValueValueResult GetCorDebugGenericValue_Value_AsString(CorDebugGenericValue corDebugGenericValue)
+	public static CorDebugValueValueResult GetCorDebugGenericValue_Value_AsString(ICorDebugGenericValue corDebugGenericValue)
 	{
 		IntPtr buffer = Marshal.AllocHGlobal(corDebugGenericValue.Size);
 		try
@@ -314,9 +314,9 @@ public partial class ManagedDebugger
 			// e.g., for int: Marshal.ReadInt32(buffer)
 			var value = corDebugGenericValue.Type switch
 			{
-				CorElementType.Void => "void",
-				CorElementType.Boolean => Marshal.ReadByte(buffer) != 0 ? "true" : "false",
-				CorElementType.Char => Marshal.ReadInt16(buffer) is var v ? $"{v} '{(char)v}'" : throw new UnreachableException(),
+				CorElementType.VOID => "void",
+				CorElementType.BOOLEAN => Marshal.ReadByte(buffer) != 0 ? "true" : "false",
+				CorElementType.CHAR => Marshal.ReadInt16(buffer) is var v ? $"{v} '{(char)v}'" : throw new UnreachableException(),
 				CorElementType.I1 => ((sbyte)Marshal.ReadByte(buffer)).ToString(),
 				CorElementType.I2 => Marshal.ReadInt16(buffer).ToString(),
 				CorElementType.I4 => Marshal.ReadInt32(buffer).ToString(),

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
@@ -331,12 +331,11 @@ public partial class ManagedDebugger
 				// native integer
 				CorElementType.I => IntPtr.Size is 4 ? Marshal.ReadInt32(buffer).ToString() : Marshal.ReadInt64(buffer).ToString(),
 				CorElementType.U => IntPtr.Size is 4 ? ((uint)Marshal.ReadInt32(buffer)).ToString() : ((ulong)Marshal.ReadInt64(buffer)).ToString(),
-				CorElementType.R => throw new NotImplementedException(),
-				CorElementType.String => throw new ArgumentOutOfRangeException(), // Marshal.PtrToStringUni(Marshal.ReadIntPtr(buffer)) ?? "null",
-				CorElementType.Ptr => throw new ArgumentOutOfRangeException(), // $"0x{Marshal.ReadIntPtr(buffer).ToInt64():X}",
-				CorElementType.ByRef => throw new ArgumentOutOfRangeException(), // $"0x{Marshal.ReadIntPtr(buffer).ToInt64():X}",
-				CorElementType.ValueType => throw new NotImplementedException(),
-				CorElementType.Class => throw new NotImplementedException(),
+				CorElementType.STRING => throw new ArgumentOutOfRangeException(), // Marshal.PtrToStringUni(Marshal.ReadIntPtr(buffer)) ?? "null",
+				CorElementType.PTR => throw new ArgumentOutOfRangeException(), // $"0x{Marshal.ReadIntPtr(buffer).ToInt64():X}",
+				CorElementType.BYREF => throw new ArgumentOutOfRangeException(), // $"0x{Marshal.ReadIntPtr(buffer).ToInt64():X}",
+				CorElementType.VALUETYPE => throw new NotImplementedException(),
+				CorElementType.CLASS => throw new NotImplementedException(),
 				_ => throw new ArgumentOutOfRangeException()
 			};
 			var friendlyTypeName = GetFriendlyTypeName(corDebugGenericValue.Type) ?? throw new ArgumentOutOfRangeException();
@@ -371,9 +370,9 @@ public partial class ManagedDebugger
 	{
 		return elementType switch
 		{
-			CorElementType.Void => "void",
-			CorElementType.Boolean => "bool",
-			CorElementType.Char => "char",
+			CorElementType.VOID => "void",
+			CorElementType.BOOLEAN => "bool",
+			CorElementType.CHAR => "char",
 			CorElementType.I1 => "sbyte",
 			CorElementType.U1 => "byte",
 			CorElementType.I2 => "short",
@@ -384,8 +383,8 @@ public partial class ManagedDebugger
 			CorElementType.U8 => "ulong",
 			CorElementType.R4 => "float",
 			CorElementType.R8 => "double",
-			CorElementType.String => "string",
-			CorElementType.Object => "object", // Should we ever see this?
+			CorElementType.STRING => "string",
+			CorElementType.OBJECT => "object", // Should we ever see this?
 			CorElementType.I => "nint",
 			CorElementType.U => "nuint",
 			_ => null

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using Ardalis.GuardClauses;
-using ClrDebug;
+using ICorDebugSharp;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator;
 using SharpDbg.Infrastructure.Debugger.ExpressionEvaluator.Compiler;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
@@ -118,13 +118,13 @@ public partial class ManagedDebugger
 			var value = GetValueForCorDebugValue(underlyingValueOrNull);
 			return value with { FriendlyTypeName = typeName };
 		}
-		var hasDebuggerTypeProxyAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.Diagnostics.DebuggerTypeProxyAttribute", out var debuggerTypeProxyAttribute) is Cor.S_OK;
-		var hasDebuggerDisplayAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.Diagnostics.DebuggerDisplayAttribute", out var debuggerDisplayAttribute) is Cor.S_OK;
+		var hasDebuggerTypeProxyAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.Diagnostics.DebuggerTypeProxyAttribute", out var debuggerTypeProxyAttributePointer, out var debuggerTypeProxyAttributeSize) is Cor.S_OK;
+		var hasDebuggerDisplayAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.Diagnostics.DebuggerDisplayAttribute", out var debuggerDisplayAttributePointer, out var debuggerDisplayAttributeSize) is Cor.S_OK;
 
-		var debugProxyTypeName = hasDebuggerTypeProxyAttribute ? GetCustomAttributeResultString(debuggerTypeProxyAttribute) : null;
+		var debugProxyTypeName = hasDebuggerTypeProxyAttribute ? GetCustomAttributeResultString(debuggerTypeProxyAttributePointer, debuggerTypeProxyAttributeSize) : null;
 		if (hasDebuggerDisplayAttribute)
 		{
-			var (debuggerDisplayValue, debuggerDisplayName) = GetCustomAttributeCtorStringArgAndNamedArg(debuggerDisplayAttribute, "Name");
+			var (debuggerDisplayValue, debuggerDisplayName) = GetCustomAttributeCtorStringArgAndNamedArg(debuggerDisplayAttributePointer, debuggerDisplayAttributeSize, "Name");
 			if (typeName.StartsWith("<>f__AnonymousType"))
 			{
 				// DebuggerDisplay Name for an anonymous type is e.g. `\{ Id = {Id}, Name = {Name} }`

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
@@ -36,7 +36,7 @@ public partial class ManagedDebugger
 			var thread = _process!.GetThread(threadId.Value);
 			var eval = thread.CreateEval();
 			var module = corDebugValue.ExactType.Class.Module;
-			var metadataImport = module.GetMetaDataInterface().MetaDataImport;
+			var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 			var debugProxyCorDebugTypeDef = metadataImport.FindMaybeNestedTypeDefByNameOrNull(debuggerProxyTypeName);
 			ArgumentNullException.ThrowIfNull(debugProxyCorDebugTypeDef);
 			var debugProxyCorDebugClass = module.GetClassFromToken(debugProxyCorDebugTypeDef.Value);
@@ -99,7 +99,7 @@ public partial class ManagedDebugger
 	public static CorDebugValueValueResult GetCorDebugObjectValue_Value_AsString(CorDebugObjectValue corDebugObjectValue)
 	{
 		var module = corDebugObjectValue.Class.Module;
-		var metaDataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		var baseTypeName = corDebugObjectValue.ExactType.Base is {} baseType ? GetCorDebugTypeFriendlyName(baseType) : null; // ExactType.Base is null when ExactType is System.Object
 		if (baseTypeName is "System.Enum")
 		{
@@ -164,7 +164,7 @@ public partial class ManagedDebugger
 		{
 			var cls = type.Class;
 			var module = cls.Module;
-			var metaDataImport = module.GetMetaDataInterface().MetaDataImport;
+			var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
 			var typeName = metaDataImport.GetTypeDefProps(cls.Token).szTypeDef;
 			if (typeName is "System.Object" or "System.ValueType") return false;
 
@@ -183,7 +183,7 @@ public partial class ManagedDebugger
 	private static CorDebugValue? GetUnderlyingValueOrNullFromNullableStruct(CorDebugObjectValue corDebugObjectValue)
 	{
 		var module = corDebugObjectValue.Class.Module;
-		var metaDataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		var hasValueFieldDef = metaDataImport.FindField(corDebugObjectValue.Class.Token, "hasValue", 0, 0);
 		var valueFieldDef = metaDataImport.FindField(corDebugObjectValue.Class.Token, "value", 0, 0);
 
@@ -234,7 +234,7 @@ public partial class ManagedDebugger
 	{
 		var module = corDebugClass.Module;
 		var token = corDebugClass.Token;
-		var metadataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metadataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		var typeDefProps = metadataImport.GetTypeDefProps(token);
 		var typeName = typeDefProps.szTypeDef;
 		var isNested = typeDefProps.pdwTypeDefFlags.IsTdNested();

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues.cs
@@ -118,8 +118,8 @@ public partial class ManagedDebugger
 			var value = GetValueForCorDebugValue(underlyingValueOrNull);
 			return value with { FriendlyTypeName = typeName };
 		}
-		var hasDebuggerTypeProxyAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.Diagnostics.DebuggerTypeProxyAttribute", out var debuggerTypeProxyAttribute) is HRESULT.S_OK;
-		var hasDebuggerDisplayAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.Diagnostics.DebuggerDisplayAttribute", out var debuggerDisplayAttribute) is HRESULT.S_OK;
+		var hasDebuggerTypeProxyAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.Diagnostics.DebuggerTypeProxyAttribute", out var debuggerTypeProxyAttribute) is Cor.S_OK;
+		var hasDebuggerDisplayAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.Diagnostics.DebuggerDisplayAttribute", out var debuggerDisplayAttribute) is Cor.S_OK;
 
 		var debugProxyTypeName = hasDebuggerTypeProxyAttribute ? GetCustomAttributeResultString(debuggerTypeProxyAttribute) : null;
 		if (hasDebuggerDisplayAttribute)

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Decimal.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Decimal.cs
@@ -1,5 +1,5 @@
 using System.Runtime.InteropServices;
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Decimal.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Decimal.cs
@@ -8,7 +8,7 @@ public partial class ManagedDebugger
 	private static string GetDecimalValueString(CorDebugObjectValue corDebugObjectValue)
 	{
 		var module = corDebugObjectValue.Class.Module;
-		var metaDataImport = module.GetMetaDataInterface().MetaDataImport;
+		var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
 		var classToken = corDebugObjectValue.Class.Token;
 
 		uint lo = 0, mid = 0, hi = 0, flags = 0;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Decimal.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Decimal.cs
@@ -22,7 +22,7 @@ public partial class ManagedDebugger
 
 			uint ReadUInt32Field()
 			{
-				var fieldValue = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class.Raw, fieldDef);
+				var fieldValue = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class, fieldDef);
 				IntPtr buffer = Marshal.AllocHGlobal(4);
 				try
 				{
@@ -55,7 +55,7 @@ public partial class ManagedDebugger
 					break;
 				case "_lo64":
 					// .NET 7+ layout: _lo64 is a ulong covering lo+mid
-					var fieldValue64 = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class.Raw, fieldDef);
+					var fieldValue64 = corDebugObjectValue.GetFieldValue(corDebugObjectValue.Class, fieldDef);
 					IntPtr buf64 = Marshal.AllocHGlobal(8);
 					try
 					{

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Decimal.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Decimal.cs
@@ -5,7 +5,7 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public partial class ManagedDebugger
 {
-	private static string GetDecimalValueString(CorDebugObjectValue corDebugObjectValue)
+	private static string GetDecimalValueString(ICorDebugObjectValue corDebugObjectValue)
 	{
 		var module = corDebugObjectValue.Class.Module;
 		var metaDataImport = module.GetMetaDataInterface<IMetaDataImport>();
@@ -26,7 +26,7 @@ public partial class ManagedDebugger
 				IntPtr buffer = Marshal.AllocHGlobal(4);
 				try
 				{
-					((CorDebugGenericValue)fieldValue.UnwrapDebugValue()).GetValue(buffer);
+					((ICorDebugGenericValue)fieldValue.UnwrapDebugValue()).GetValue(buffer);
 					return (uint)Marshal.ReadInt32(buffer);
 				}
 				finally
@@ -59,7 +59,7 @@ public partial class ManagedDebugger
 					IntPtr buf64 = Marshal.AllocHGlobal(8);
 					try
 					{
-						((CorDebugGenericValue)fieldValue64.UnwrapDebugValue()).GetValue(buf64);
+						((ICorDebugGenericValue)fieldValue64.UnwrapDebugValue()).GetValue(buf64);
 						var raw64 = (ulong)Marshal.ReadInt64(buf64);
 						lo = (uint)(raw64 & 0xFFFFFFFF);
 						mid = (uint)(raw64 >> 32);

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Enum.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Enum.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Enum.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Enum.cs
@@ -6,7 +6,7 @@ public partial class ManagedDebugger
 {
 	private static string GetEnumDisplayValue(MetaDataImport metaDataImport, CorDebugObjectValue corDebugObjectValue, string valueAsString)
 	{
-		var hasFlagsAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.FlagsAttribute", out _) is HRESULT.S_OK;
+		var hasFlagsAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.FlagsAttribute", out _) is Cor.S_OK;
 
 		// Fast path: exact match
 		var exact = GetEnumNameForValue(metaDataImport, corDebugObjectValue, valueAsString);

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Enum.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_Enum.cs
@@ -4,9 +4,9 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public partial class ManagedDebugger
 {
-	private static string GetEnumDisplayValue(MetaDataImport metaDataImport, CorDebugObjectValue corDebugObjectValue, string valueAsString)
+	private static string GetEnumDisplayValue(IMetaDataImport metaDataImport, ICorDebugObjectValue corDebugObjectValue, string valueAsString)
 	{
-		var hasFlagsAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.FlagsAttribute", out _) is Cor.S_OK;
+		var hasFlagsAttribute = metaDataImport.TryGetCustomAttributeByName(corDebugObjectValue.Class.Token, "System.FlagsAttribute", out _, out _) is Cor.S_OK;
 
 		// Fast path: exact match
 		var exact = GetEnumNameForValue(metaDataImport, corDebugObjectValue, valueAsString);
@@ -17,7 +17,7 @@ public partial class ManagedDebugger
 		return GetFlagsEnumValue(metaDataImport, corDebugObjectValue, valueAsString);
 	}
 
-	private static string? GetEnumNameForValue(MetaDataImport metaDataImport, CorDebugObjectValue corDebugObjectValue, string valueAsString)
+	private static string? GetEnumNameForValue(IMetaDataImport metaDataImport, ICorDebugObjectValue corDebugObjectValue, string valueAsString)
 	{
 		var fields = metaDataImport.EnumFields(corDebugObjectValue.Class.Token);
 		foreach (var field in fields)
@@ -34,7 +34,7 @@ public partial class ManagedDebugger
 		return null;
 	}
 
-	private static string GetFlagsEnumValue(MetaDataImport metaDataImport, CorDebugObjectValue corDebugObjectValue, string valueAsString)
+	private static string GetFlagsEnumValue(IMetaDataImport metaDataImport, ICorDebugObjectValue corDebugObjectValue, string valueAsString)
 	{
 		if (!ulong.TryParse(valueAsString, out var enumValue))
 			return valueAsString;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_ReadMetadata.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_ReadMetadata.cs
@@ -6,11 +6,10 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public partial class ManagedDebugger
 {
-	private static int GetDebuggerBrowsableCustomAttributeResultInt(GetCustomAttributeByNameResult attribute)
+	private static int GetDebuggerBrowsableCustomAttributeResultInt(nint debuggerBrowsableCustomAttributePointer, uint debuggerBrowsableCustomAttributeSize)
 	{
-		var dataIntPtr = attribute.ppData;
-		var byteArray = new byte[attribute.pcbData];
-		Marshal.Copy(dataIntPtr, byteArray, 0, byteArray.Length);
+		var byteArray = new byte[debuggerBrowsableCustomAttributeSize];
+		Marshal.Copy(debuggerBrowsableCustomAttributePointer, byteArray, 0, byteArray.Length);
 		// 2 bytes prolog
 		// 4 bytes data
 		// 2 bytes alignment
@@ -19,9 +18,9 @@ public partial class ManagedDebugger
 		return dataAsInt;
 	}
 
-	private static string GetCustomAttributeResultString(GetCustomAttributeByNameResult attribute)
+	private static string GetCustomAttributeResultString(nint customAttributePointer, uint customAttributeSize)
 	{
-		var dataAsString = GetCustomAttributeCtorStringArg(attribute.ppData, attribute.pcbData); // e.g. "Count = {Count}" or "{DebuggerDisplay,nq}"
+		var dataAsString = GetCustomAttributeCtorStringArg(customAttributePointer, checked((int)customAttributeSize)); // e.g. "Count = {Count}" or "{DebuggerDisplay,nq}"
 		return dataAsString ?? string.Empty;
 	}
 
@@ -38,7 +37,7 @@ public partial class ManagedDebugger
 		var stringCtorArg = reader.ReadSerializedString();
 		return stringCtorArg;
 	}
-	private static (string, string?) GetCustomAttributeCtorStringArgAndNamedArg(GetCustomAttributeByNameResult customAttributeByNameResult, string namedArgumentName) => GetCustomAttributeCtorStringArgAndNamedArg(customAttributeByNameResult.ppData, customAttributeByNameResult.pcbData, namedArgumentName)!;
+	private static (string, string?) GetCustomAttributeCtorStringArgAndNamedArg(nint customAttributePointer, uint customAttributeSize, string namedArgumentName) => GetCustomAttributeCtorStringArgAndNamedArg(customAttributePointer, checked((int)customAttributeSize), namedArgumentName)!;
 
 	private static unsafe (string?, string?) GetCustomAttributeCtorStringArgAndNamedArg(IntPtr ppData, int pcbData, string namedArgumentName)
 	{

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_ReadMetadata.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_VariableValues_ReadMetadata.cs
@@ -1,6 +1,6 @@
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ModuleInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ModuleInfo.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
 

--- a/src/SharpDbg.Infrastructure/Debugger/ModuleInfo.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ModuleInfo.cs
@@ -10,7 +10,7 @@ public class ModuleInfo : IDisposable
 	/// <summary>
 	/// The ICorDebugModule for this module
 	/// </summary>
-	public CorDebugModule Module { get; }
+	public ICorDebugModule Module { get; }
 
 	/// <summary>
 	/// Full path to the module on disk (if available)
@@ -34,7 +34,7 @@ public class ModuleInfo : IDisposable
 	public CORDB_ADDRESS BaseAddress { get; }
 	public bool IsUserCode { get; }
 
-	public ModuleInfo(CorDebugModule module, string modulePath, SymbolReader? symbolReader, bool isUserCode)
+	public ModuleInfo(ICorDebugModule module, string modulePath, SymbolReader? symbolReader, bool isUserCode)
 	{
 		Module = module;
 		ModulePath = modulePath;

--- a/src/SharpDbg.Infrastructure/Debugger/SymbolReader.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/SymbolReader.cs
@@ -2,7 +2,7 @@ using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using ClrDebug;
+using ICorDebugSharp;
 using ZLinq;
 
 namespace SharpDbg.Infrastructure.Debugger;

--- a/src/SharpDbg.Infrastructure/Debugger/SymbolReader.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/SymbolReader.cs
@@ -380,7 +380,7 @@ public partial class SymbolReader : IDisposable
 		return (ilStartOffset, ilEndOffset);
 	}
 
-	public (int currentIlOffset, int? nextUserCodeIlOffset) GetFrameCurrentIlOffsetAndNextUserCodeIlOffset(CorDebugILFrame ilFrame)
+	public (int currentIlOffset, int? nextUserCodeIlOffset) GetFrameCurrentIlOffsetAndNextUserCodeIlOffset(ICorDebugILFrame ilFrame)
 	{
 		var method = ilFrame.Function;
 		var code = method.ILCode;

--- a/src/SharpDbg.Infrastructure/Debugger/VariableManager.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/VariableManager.cs
@@ -1,4 +1,4 @@
-using ClrDebug;
+using ICorDebugSharp;
 
 namespace SharpDbg.Infrastructure.Debugger;
 

--- a/src/SharpDbg.Infrastructure/Debugger/VariableManager.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/VariableManager.cs
@@ -29,7 +29,7 @@ public readonly record struct FrameStackDepth
 		Value = value;
 	}
 };
-public record struct VariablesReference(StoredReferenceKind ReferenceKind, CorDebugValue? ObjectValue, ThreadId ThreadId, FrameStackDepth FrameStackDepth, CorDebugValue? DebuggerProxyInstance);
+public record struct VariablesReference(StoredReferenceKind ReferenceKind, ICorDebugValue? ObjectValue, ThreadId ThreadId, FrameStackDepth FrameStackDepth, ICorDebugValue? DebuggerProxyInstance);
 /// <summary>
 /// Manages variable references for scopes and variables
 /// </summary>
@@ -92,12 +92,12 @@ public class VariableManager
 		}
 	}
 
-	private static IEnumerable<CorDebugHandleValue> GetHandleValues(VariablesReference r)
+	private static IEnumerable<ICorDebugHandleValue> GetHandleValues(VariablesReference r)
 	{
-		if (r.ObjectValue is CorDebugHandleValue ov)
+		if (r.ObjectValue is ICorDebugHandleValue ov)
 			yield return ov;
 
-		if (r.DebuggerProxyInstance is CorDebugHandleValue dp)
+		if (r.DebuggerProxyInstance is ICorDebugHandleValue dp)
 			yield return dp;
 	}
 }

--- a/src/SharpDbg.Infrastructure/GlobalUsings.cs
+++ b/src/SharpDbg.Infrastructure/GlobalUsings.cs
@@ -1,0 +1,1 @@
+﻿global using ICorDebugSharp.Extensions;

--- a/src/SharpDbg.Infrastructure/SharpDbg.Infrastructure.csproj
+++ b/src/SharpDbg.Infrastructure/SharpDbg.Infrastructure.csproj
@@ -19,7 +19,7 @@
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
     <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-	<PackageReference Include="ICorDebugSharp" Version="0.1.0" />
+	<PackageReference Include="ICorDebugSharp" Version="0.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />

--- a/src/SharpDbg.Infrastructure/SharpDbg.Infrastructure.csproj
+++ b/src/SharpDbg.Infrastructure/SharpDbg.Infrastructure.csproj
@@ -19,7 +19,7 @@
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
     <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-    <PackageReference Include="ClrDebug" Version="0.3.4" />
+	<PackageReference Include="ICorDebugSharp" Version="0.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />


### PR DESCRIPTION
ClrDebug has unreleased fixes and publishes releases with irregular cadence, and also still supports .NET Standard 2.0/.NET Framework, so makes compromises around source generated COM interfaces etc, and additionally uses managed C# class wrappers around all of the COM interfaces.

I have built my own code generator for cordebug.idl, metahost.idl, dbgshim.h, cor.h and corhdr.h, to fully [GeneratedComInterface] COM interfaces, targeting .NET 10+ only - https://github.com/MattParkerDev/ICorDebugSharp. All higher level methods wrapping low level interface methods are implemented as extension methods or extension properties, resulting in the same ergonomics as ClrDebug without the managed class wrappers.

This PR replaces ClrDebug with ICorDebugSharp.

All tests are passing on Windows, MacOS and Linux.
<!-- PR description above this line -->
#
> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/sharpdbg/blob/main/CONTRIBUTING.md#legal-notice)
