### PR TITLE
✨ Implement SetFunctionBreakpoints support

### DIFF
--- a/src/SharpDbg.Application/DebugAdapter.cs
+++ b/src/SharpDbg.Application/DebugAdapter.cs
@@ -93,6 +93,7 @@ public class DebugAdapter : DebugAdapterBase
 
 		_debugger.OnBreakpointChanged += breakpoint =>
 		{
+			var isFunctionBreakpoint = breakpoint.FunctionName is not null;
 			Protocol.SendEvent(new BreakpointEvent
 			{
 				Reason = BreakpointEvent.ReasonValue.Changed,
@@ -100,13 +101,13 @@ public class DebugAdapter : DebugAdapterBase
 				{
 					Id = breakpoint.Id,
 					Verified = breakpoint.Verified,
-					Line = ConvertDebuggerLineToClient(breakpoint.Line),
-					Column = breakpoint is { Verified: true, Column: not null } ? ConvertDebuggerColumnToClient(breakpoint.Column.Value) : null,
-					EndLine = breakpoint.Verified ? breakpoint.EndLine : null,
-					EndColumn = breakpoint is { Verified: true, EndColumn: not null } ? ConvertDebuggerColumnToClient(breakpoint.EndColumn.Value) : null,
+					Line = isFunctionBreakpoint ? null : ConvertDebuggerLineToClient(breakpoint.Line),
+					Column = breakpoint is { Verified: true, Column: not null } && !isFunctionBreakpoint ? ConvertDebuggerColumnToClient(breakpoint.Column.Value) : null,
+					EndLine = breakpoint.Verified && !isFunctionBreakpoint ? breakpoint.EndLine : null,
+					EndColumn = breakpoint is { Verified: true, EndColumn: not null } && !isFunctionBreakpoint ? ConvertDebuggerColumnToClient(breakpoint.EndColumn.Value) : null,
 					Offset = breakpoint.Verified ? 0 : null,
 					Message = breakpoint.Message,
-					Source = breakpoint.Verified is false ? null : new Source
+					Source = breakpoint.Verified is false || isFunctionBreakpoint ? null : new Source
 					{
 						Path = breakpoint.FilePath,
 						Name = Path.GetFileName(breakpoint.FilePath),
@@ -384,11 +385,23 @@ public class DebugAdapter : DebugAdapterBase
 
 	protected override SetFunctionBreakpointsResponse HandleSetFunctionBreakpointsRequest(SetFunctionBreakpointsArguments arguments)
 	{
-		// Function breakpoints not yet fully implemented
-		return new SetFunctionBreakpointsResponse
+		return ExecuteWithExceptionHandling(() =>
 		{
-			Breakpoints = []
-		};
+			var functionBreakpoints = arguments.Breakpoints?
+				.Select(bp => new SharpDbgFunctionBreakpointRequest(bp.Name, bp.Condition, bp.HitCondition, bp.LogMessage))
+				.ToArray() ?? [];
+
+			var breakpoints = _debugger.SetFunctionBreakpoints(functionBreakpoints);
+
+			var dapBreakpoints = breakpoints.Select(bp => new MSBreakpoint
+			{
+				Id = bp.Id,
+				Verified = bp.Verified,
+				Message = bp.Message
+			}).ToList();
+
+			return new SetFunctionBreakpointsResponse { Breakpoints = dapBreakpoints };
+		});
 	}
 
 	protected override SetExceptionBreakpointsResponse HandleSetExceptionBreakpointsRequest(SetExceptionBreakpointsArguments arguments)

--- a/src/SharpDbg.Infrastructure/Debugger/BreakpointManager.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/BreakpointManager.cs
@@ -10,6 +10,7 @@ public class BreakpointManager
 	private int _nextBreakpointId = 1;
 	private readonly Dictionary<int, BreakpointInfo> _breakpoints = new();
 	private readonly Dictionary<string, List<int>> _breakpointsByFile = new();
+	private readonly Dictionary<string, List<int>> _functionBreakpoints = new();
 	private readonly Lock _lock = new();
 
 	public class BreakpointInfo
@@ -26,6 +27,9 @@ public class BreakpointManager
 		public SymbolReader.ResolvedBreakpoint? ResolvedBreakpointFromPdb { get; set; }
 		public CORDB_ADDRESS? ModuleBaseAddress { get; set; }
 
+		/// <summary>Function name for SetFunctionBreakpoints support</summary>
+		public string? FunctionName { get; set; }
+
 		/// <summary>Conditional expression to evaluate when breakpoint is hit</summary>
 		public string? Condition { get; set; }
 
@@ -37,7 +41,7 @@ public class BreakpointManager
 	}
 
 	/// <summary>
-	/// Create a new breakpoint
+	/// Create a new source breakpoint
 	/// </summary>
 	public BreakpointInfo CreateBreakpoint(string filePath, int line, int? column = null, string? condition = null, string? hitCondition = null)
 	{
@@ -65,6 +69,39 @@ public class BreakpointManager
 				_breakpointsByFile[filePath] = [];
 			}
 			_breakpointsByFile[filePath].Add(id);
+
+			return bp;
+		}
+	}
+
+	/// <summary>
+	/// Create a new function breakpoint
+	/// </summary>
+	public BreakpointInfo CreateFunctionBreakpoint(string functionName, string? condition = null, string? hitCondition = null)
+	{
+		lock (_lock)
+		{
+			var id = _nextBreakpointId++;
+			if (string.IsNullOrWhiteSpace(condition)) condition = null;
+			if (string.IsNullOrWhiteSpace(hitCondition)) hitCondition = null;
+			var bp = new BreakpointInfo
+			{
+				Id = id,
+				FunctionName = functionName,
+				FilePath = functionName, // use function name as file path for event routing compatibility
+				Verified = false,
+				Condition = condition,
+				HitCondition = hitCondition,
+				HitCount = 0
+			};
+
+			_breakpoints[id] = bp;
+
+			if (!_functionBreakpoints.ContainsKey(functionName))
+			{
+				_functionBreakpoints[functionName] = [];
+			}
+			_functionBreakpoints[functionName].Add(id);
 
 			return bp;
 		}
@@ -115,6 +152,35 @@ public class BreakpointManager
 	}
 
 	/// <summary>
+	/// Clear all function breakpoints
+	/// </summary>
+	public void ClearAllFunctionBreakpoints()
+	{
+		lock (_lock)
+		{
+			foreach (var (_, ids) in _functionBreakpoints)
+			{
+				foreach (var id in ids)
+				{
+					_breakpoints.Remove(id);
+				}
+			}
+			_functionBreakpoints.Clear();
+		}
+	}
+
+	/// <summary>
+	/// Get all function breakpoints
+	/// </summary>
+	public List<BreakpointInfo> GetAllFunctionBreakpoints()
+	{
+		lock (_lock)
+		{
+			return _functionBreakpoints.Values.SelectMany(ids => ids).Select(id => _breakpoints[id]).ToList();
+		}
+	}
+
+	/// <summary>
 	/// Find breakpoint by ClrDebug breakpoint
 	/// </summary>
 	public BreakpointInfo? FindByCorBreakpoint(ICorDebugFunctionBreakpoint corBreakpoint)
@@ -161,6 +227,11 @@ public class BreakpointManager
 				ids.Remove(id);
 				if (ids.Count == 0) _breakpointsByFile.Remove(bp.FilePath);
 			}
+			if (bp.FunctionName is not null && _functionBreakpoints.TryGetValue(bp.FunctionName, out var fnIds))
+			{
+				fnIds.Remove(id);
+				if (fnIds.Count == 0) _functionBreakpoints.Remove(bp.FunctionName);
+			}
 			return true;
 		}
 	}
@@ -174,6 +245,7 @@ public class BreakpointManager
 		{
 			_breakpoints.Clear();
 			_breakpointsByFile.Clear();
+			_functionBreakpoints.Clear();
 			_nextBreakpointId = 1;
 		}
 	}

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
@@ -272,7 +272,14 @@ public partial class ManagedDebugger
 
 		foreach (var bp in pendingBreakpoints)
 		{
-			if (TryBindBreakpoint(bp))
+			if (bp.FunctionName is not null)
+			{
+				if (TryBindFunctionBreakpoint(bp))
+				{
+					OnBreakpointChanged?.Invoke(bp);
+				}
+			}
+			else if (TryBindBreakpoint(bp))
 			{
 				// Notify that the breakpoint changed (became verified)
 				OnBreakpointChanged?.Invoke(bp);

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
@@ -186,7 +186,21 @@ public partial class ManagedDebugger
 			return;
 		}
 
-		if (managedBreakpoint.ResolvedBreakpointFromPdb is not {} resolvedBreakpoint) throw new UnreachableException("Breakpoint was not resolved from PDB - this should never happen, as breakpoints are only bound to resolved source locations");
+		if (managedBreakpoint.ResolvedBreakpointFromPdb is not {} resolvedBreakpoint)
+		{
+			// Function breakpoints do not have pre-resolved PDB info — get source location from current frame
+			if (managedBreakpoint.FunctionName is not null)
+			{
+				var sourceInfo = GetSourceInfoAtFrame(corThread.ActiveFrame);
+				if (sourceInfo is not null)
+				{
+					OnStopped2?.Invoke(corThread.Id, sourceInfo.Value.FilePath, sourceInfo.Value.StartLine,
+						sourceInfo.Value.StartColumn, "function breakpoint", sourceInfo.Value.DecompiledSourceInfo);
+					return;
+				}
+			}
+			throw new UnreachableException("Breakpoint was not resolved from PDB and is not a function breakpoint — this should never happen");
+		}
 		OnStopped2?.Invoke(corThread.Id, managedBreakpoint.FilePath, resolvedBreakpoint.StartLine, resolvedBreakpoint.StartColumn, "breakpoint", null);
 	}
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
@@ -14,6 +14,8 @@ namespace SharpDbg.Infrastructure.Debugger;
 
 public record SharpDbgBreakpointRequest(int Line, string? Condition = null, string? HitCondition = null, int? Column = null);
 
+public record SharpDbgFunctionBreakpointRequest(string Name, string? Condition = null, string? HitCondition = null, string? LogMessage = null);
+
 public partial class ManagedDebugger
 {
 	// Store launch info for deferred attach in ConfigurationDone
@@ -326,6 +328,146 @@ public partial class ManagedDebugger
 		}
 
 		return result;
+	}
+
+	/// <summary>
+	/// Set function breakpoints by method name
+	/// </summary>
+	public List<BreakpointManager.BreakpointInfo> SetFunctionBreakpoints(SharpDbgFunctionBreakpointRequest[] breakpoints)
+	{
+		_logger?.Invoke($"SetFunctionBreakpoints: {string.Join(", ", breakpoints.Select(b => $"'{b.Name}' {(b.Condition is not null ? $"[{b.Condition}]" : null)}"))}");
+
+		// Deactivate existing function breakpoints
+		var existing = _breakpointManager.GetAllFunctionBreakpoints();
+		foreach (var bp in existing)
+		{
+			if (bp.CorBreakpoint is not null)
+			{
+				try
+				{
+					bp.CorBreakpoint.Activate(false);
+				}
+				catch (Exception ex)
+				{
+					_logger?.Invoke($"Error deactivating function breakpoint: {ex.Message}");
+				}
+			}
+		}
+		_breakpointManager.ClearAllFunctionBreakpoints();
+
+		// Create new function breakpoints
+		var result = new List<BreakpointManager.BreakpointInfo>();
+		foreach (var request in breakpoints)
+		{
+			var bp = _breakpointManager.CreateFunctionBreakpoint(request.Name, request.Condition, request.HitCondition);
+
+			if (_process is not null)
+			{
+				TryBindFunctionBreakpoint(bp);
+			}
+			else
+			{
+				bp.Message = "Breakpoint has not been processed by the debugger.";
+			}
+
+			result.Add(bp);
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// Try to bind a function breakpoint by searching metadata across all loaded modules
+	/// </summary>
+	private bool TryBindFunctionBreakpoint(BreakpointManager.BreakpointInfo bp)
+	{
+		var functionName = bp.FunctionName;
+		if (string.IsNullOrWhiteSpace(functionName) || _process is null) return false;
+
+		// Parse: last segment = method name, everything before = type pattern
+		var lastDot = functionName.LastIndexOf('.');
+		var methodName = lastDot >= 0 ? functionName[(lastDot + 1)..] : functionName;
+		var typePattern = lastDot >= 0 ? functionName[..lastDot] : null;
+
+		foreach (var moduleInfo in _modules.Values)
+		{
+			var metadataImport = moduleInfo.Module.GetMetaDataInterface<IMetaDataImport>();
+
+			if (typePattern is not null)
+			{
+				// Try exact type match (e.g., "MyNamespace.MyClass")
+				var typeDef = metadataImport.FindTypeDefByNameOrNull(typePattern, mdToken.Nil)
+					?? metadataImport.FindMaybeNestedTypeDefByNameOrNull(typePattern);
+
+				if (typeDef is not null)
+				{
+					if (TryBindOnType(moduleInfo, typeDef.Value, methodName, bp))
+						return true;
+				}
+
+				// Try suffix match: walk all TypeDefs and match by szTypeDef
+				foreach (var td in metadataImport.EnumTypeDefs())
+				{
+					if (td.IsNil) continue;
+					var props = metadataImport.GetTypeDefProps(td);
+					if (props.szTypeDef.Equals(typePattern, StringComparison.Ordinal) ||
+						props.szTypeDef.EndsWith("." + typePattern, StringComparison.Ordinal))
+					{
+						if (TryBindOnType(moduleInfo, td, methodName, bp))
+							return true;
+					}
+				}
+			}
+			else
+			{
+				// No type pattern — search all methods across all types
+				foreach (var td in metadataImport.EnumTypeDefs())
+				{
+					if (td.IsNil) continue;
+					if (TryBindOnType(moduleInfo, td, methodName, bp))
+						return true;
+				}
+			}
+		}
+
+		bp.Verified = false;
+		bp.Message = $"Could not resolve function name: '{functionName}'. No matching method found in any loaded module.";
+		return false;
+	}
+
+	/// <summary>
+	/// Try to bind a function breakpoint on a specific type definition
+	/// </summary>
+	private bool TryBindOnType(ModuleInfo moduleInfo, mdTypeDef typeDef, string methodName, BreakpointManager.BreakpointInfo bp)
+	{
+		var metadataImport = moduleInfo.Module.GetMetaDataInterface<IMetaDataImport>();
+		var methodTokens = metadataImport.EnumMethods(typeDef);
+
+		foreach (var methodToken in methodTokens)
+		{
+			if (methodToken.IsNil) continue;
+			var methodProps = metadataImport.GetMethodProps(methodToken);
+			if (!methodProps.szMethod.Equals(methodName, StringComparison.Ordinal))
+				continue;
+
+			var function = moduleInfo.Module.GetFunctionFromToken(methodToken);
+			var ilCode = function.ILCode;
+
+			var corBreakpoint = ilCode.CreateBreakpoint(0);
+			corBreakpoint.Activate(true);
+
+			var typeProps = metadataImport.GetTypeDefProps(typeDef);
+
+			bp.CorBreakpoint = corBreakpoint;
+			bp.Verified = true;
+			bp.ModuleBaseAddress = moduleInfo.BaseAddress;
+			bp.Message = null;
+
+			_logger?.Invoke($"Function breakpoint bound: '{bp.FunctionName}' -> {typeProps.szTypeDef}.{methodName}() in {Path.GetFileName(moduleInfo.ModuleName)}");
+			return true;
+		}
+
+		return false;
 	}
 
 	/// <summary>

--- a/tests/DebuggableConsoleApp/FunctionBreakpointTarget.cs
+++ b/tests/DebuggableConsoleApp/FunctionBreakpointTarget.cs
@@ -1,0 +1,10 @@
+namespace DebuggableConsoleApp;
+
+public class FunctionBreakpointTarget
+{
+	public static void TargetMethod()
+	{
+		var localInTarget = "function-breakpoint-hit";
+		Console.WriteLine($"Function breakpoint: {localInTarget}");
+	}
+}

--- a/tests/DebuggableConsoleApp/Program.cs
+++ b/tests/DebuggableConsoleApp/Program.cs
@@ -32,6 +32,7 @@ public static class Program
 			var asyncResult = myAsyncClass.MyMethodAsync(4).GetAwaiter().GetResult();
 			myAsyncMethodEvalClass.Test().GetAwaiter().GetResult();
 			Exceptions.Test(exceptionToThrow);
+			FunctionBreakpointTarget.TargetMethod();
 			Thread.Sleep(100);
 			//await Task.Delay(500);
 		}

--- a/tests/SharpDbg.Cli.Tests/FunctionBreakpointTests.cs
+++ b/tests/SharpDbg.Cli.Tests/FunctionBreakpointTests.cs
@@ -1,0 +1,98 @@
+using AwesomeAssertions;
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol;
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using SharpDbg.Cli.Tests.Helpers;
+
+namespace SharpDbg.Cli.Tests;
+
+public class FunctionBreakpointTests(ITestOutputHelper testOutputHelper)
+{
+	[Fact]
+	public async Task SharpDbgCli_SetFunctionBreakpoint_HitsAndStopsAtTargetMethod()
+	{
+		var startSuspended = true;
+		var (debugProtocolHost, initializedEventTcs, debugEventTcs, adapter, p2) = TestHelper.GetRunningDebugProtocolHostInProc(testOutputHelper, startSuspended);
+		using var _ = adapter;
+		using var __ = new ProcessKiller(p2);
+		using var ___ = debugProtocolHost;
+
+		await debugProtocolHost
+			.WithInitializeRequest()
+			.WithAttachRequest(p2.Id)
+			.WaitForInitializedEvent(initializedEventTcs);
+
+		// Set function breakpoint BEFORE ConfigurationDone, same pattern as source breakpoints
+		var response = debugProtocolHost.SendRequestSync(new SetFunctionBreakpointsRequest
+		{
+			Breakpoints = [new FunctionBreakpoint { Name = "DebuggableConsoleApp.FunctionBreakpointTarget.TargetMethod" }]
+		});
+		response.Breakpoints.Should().HaveCount(1);
+
+		debugProtocolHost
+			.WithConfigurationDoneRequest()
+			.WithOptionalResumeRuntime(p2.Id, startSuspended);
+
+		// First BreakpointEvent: pending (Verified=false) from SendAllBreakpointEvents during attach
+		var bpEvent1 = await debugProtocolHost.WaitForEvent<BreakpointEvent>(debugEventTcs,
+			e => e.Breakpoint.Id == response.Breakpoints[0].Id);
+		bpEvent1.Breakpoint.Verified.Should().BeFalse();
+
+		// Second BreakpointEvent: verified (Verified=true) from TryBindPendingBreakpoints when modules load
+		var bpEvent2 = await debugProtocolHost.WaitForEvent<BreakpointEvent>(debugEventTcs, e => e.Breakpoint.Verified);
+		bpEvent2.Breakpoint.Verified.Should().BeTrue();
+		bpEvent2.Breakpoint.Id.Should().Be(response.Breakpoints[0].Id);
+
+		// Now the breakpoint should hit on the next iteration
+		var stoppedEvent = await debugProtocolHost.WaitForStoppedEvent(debugEventTcs);
+
+		stoppedEvent.Reason.Should().Be(StoppedEvent.ReasonValue.FunctionBreakpoint);
+		var stopInfo = stoppedEvent.ReadStopInfo();
+		stopInfo.filePath.Should().EndWith("FunctionBreakpointTarget.cs");
+
+		// Verify the function breakpoint stopped at the correct location
+		debugProtocolHost.WithStackTraceRequest(stoppedEvent.ThreadId!.Value, out var stackResponse);
+		var frameId = stackResponse.StackFrames[0].Id;
+		stackResponse.StackFrames[0].Name.Should().Contain("FunctionBreakpointTarget.TargetMethod");
+		stackResponse.StackFrames[0].Source.Path.Should().EndWith("FunctionBreakpointTarget.cs");
+
+		// Verify local variable exists (null at function entry, before assignment)
+		debugProtocolHost.WithScopesRequest(frameId, out var scopes);
+		var localsRef = scopes.Scopes.Single(s => s.Name == "Locals").VariablesReference;
+		debugProtocolHost.WithVariablesRequest(localsRef, out var variables);
+		variables.Should().Contain(v => v.Name == "localInTarget");
+	}
+
+	[Fact]
+	public async Task SharpDbgCli_SetFunctionBreakpoint_ByClassAndMethodName_HitsCorrectly()
+	{
+		var startSuspended = true;
+		var (debugProtocolHost, initializedEventTcs, debugEventTcs, adapter, p2) = TestHelper.GetRunningDebugProtocolHostInProc(testOutputHelper, startSuspended);
+		using var _ = adapter;
+		using var __ = new ProcessKiller(p2);
+		using var ___ = debugProtocolHost;
+
+		await debugProtocolHost
+			.WithInitializeRequest()
+			.WithAttachRequest(p2.Id)
+			.WaitForInitializedEvent(initializedEventTcs);
+
+		// Just class name + method name (no namespace)
+		var response = debugProtocolHost.SendRequestSync(new SetFunctionBreakpointsRequest
+		{
+			Breakpoints = [new FunctionBreakpoint { Name = "FunctionBreakpointTarget.TargetMethod" }]
+		});
+		response.Breakpoints.Should().HaveCount(1);
+
+		debugProtocolHost
+			.WithConfigurationDoneRequest()
+			.WithOptionalResumeRuntime(p2.Id, startSuspended);
+
+		// Wait for pending then verified
+		await debugProtocolHost.WaitForEvent<BreakpointEvent>(debugEventTcs,
+			e => e.Breakpoint.Id == response.Breakpoints[0].Id && !e.Breakpoint.Verified);
+		await debugProtocolHost.WaitForEvent<BreakpointEvent>(debugEventTcs, e => e.Breakpoint.Verified);
+
+		var stoppedEvent = await debugProtocolHost.WaitForStoppedEvent(debugEventTcs);
+		stoppedEvent.Reason.Should().Be(StoppedEvent.ReasonValue.FunctionBreakpoint);
+	}
+}


### PR DESCRIPTION
## Summary

- Wire up `HandleSetFunctionBreakpointsRequest` in the DAP adapter layer
- Search loaded modules' `IMetaDataImport` for matching type/method names
- Create `ICorDebugFunctionBreakpoint` at IL offset 0 for each resolved method
- On hit, resolve source location from the current frame (function breakpoints have no pre-resolved PDB source location)
- Support full-qualified names (`Namespace.Class.Method`) and short names (`Class.Method`)
- Add `FunctionBreakpointTarget` to the test debuggee and two integration tests

## Test plan

- [x] `SharpDbgCli_SetFunctionBreakpoint_HitsAndStopsAtTargetMethod` — full namespace + class + method name
- [x] `SharpDbgCli_SetFunctionBreakpoint_ByClassAndMethodName_HitsCorrectly` — class + method name only (suffix match)
- [x] All 11 existing Breakpoint / Variables / ConditionalBreakpoint tests still pass

> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/sharpdbg/blob/main/CONTRIBUTING.md#legal-notice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)