### PR TITLE
Fix the recovery after a failed event handler - the condition is inverted

### DIFF
--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
@@ -143,11 +143,18 @@ public partial class ManagedDebugger
 		catch (Exception ex)
 		{
 			_logger?.Invoke($"Error handling event {e.GetType().Name}: {ex}");
+
+			// The process is stopped while a callback is being dispatched, and the handler that just
+			// failed is the one that owed it a Continue. Without this the debuggee stays suspended
+			// forever with the client still believing it is running, and only Disconnect releases it.
+			// TryContinue, because the handler may well have continued before it threw, in which case
+			// this is a superfluous continue rather than an error.
 			var isRunning = false;
-			_process?.TryIsRunning(out isRunning);
-			if (isRunning)
+			if (_process?.TryIsRunning(out isRunning) is Cor.S_OK && isRunning is false)
 			{
-				Continue();
+				var result = _process.TryContinue(false);
+				if (result is not (Cor.S_OK or Cor.CORDBG_E_SUPERFLOUS_CONTINUE))
+					_logger?.Invoke($"Failed to continue after the failed event handler: 0x{result:X8}");
 			}
 		}
 	}


### PR DESCRIPTION
### What breaks

Every callback the runtime delivers stops the process and owes exactly one `Continue`. A handler that throws before issuing it leaves that debt unpaid, and nothing else pays it. The debuggee stays suspended while the client is still told it is running, and only `Disconnect` releases it.

### Why the existing recovery does not catch it

[2c9ea09](https://github.com/MattParkerDev/sharpdbg/commit/2c9ea09) added recovery for exactly this, but it is guarded by the wrong side of the condition:

```csharp
var isRunning = false;
_process?.TryIsRunning(out isRunning);
if (isRunning)          // never true here
{
    Continue();
}
```

`IsRunning` asks whether the process is running freely, and inside a callback it never is. So the recovery is skipped exactly when it is needed, and would only fire in the case where there is nothing to continue.

### The fix

```csharp
var isRunning = false;
if (_process?.TryIsRunning(out isRunning) is Cor.S_OK && isRunning is false)
{
    var result = _process.TryContinue(false);
    if (result is not (Cor.S_OK or Cor.CORDBG_E_SUPERFLOUS_CONTINUE))
        _logger?.Invoke($"Failed to continue after the failed event handler: 0x{result:X8}");
}
```

Three things beyond reversing the condition:

- `TryContinue` rather than `Continue`, because a handler that threw *after* continuing makes this one superfluous rather than wrong. `CORDBG_E_SUPERFLOUS_CONTINUE` is the expected result there, and throwing out of a catch block inside `async void` would replace one silent failure with another.
- Any other HRESULT is logged rather than swallowed.
- `TryIsRunning`'s own result is checked. If that call fails, `isRunning` stays `false` by default, and the current code would go on to continue a process it could not query.

### How to reproduce

https://github.com/nevse/sharpdbg-bug-failed-handler-freezes-debuggee

```bash
git clone https://github.com/nevse/sharpdbg-bug-failed-handler-freezes-debuggee.git
cd sharpdbg-bug-failed-handler-freezes-debuggee
dotnet build
dotnet run --project src/Repro
```

The debuggee loops, incrementing a counter and printing it every 200ms. The driver attaches, breaks on the loop body, and throws from its own `OnStopped2` subscriber - which runs inside `HandleBreakpoint`, so the exception reaches `OnAnyEvent`'s catch block. That is the deterministic way in.

After that the driver issues **no** `Continue` of its own, and watches the debuggee's own output for five seconds. That matters: what is broken here is precisely what the debugger reports, so asking it whether the process is running is no good.

On 0.1.9:

```
== throwing from the stop handler, which fails the debugger's event handler ==
  [debugger] Error handling event BreakpointCorDebugManagedCallbackEventArgs:
             System.InvalidOperationException: repro: the stop handler failed

since the failed handler, with no continue from the client:
  lines printed by the debuggee : 0
  further stops reported        : 0

== disconnecting, which is the only thing that releases it ==
debuggee printed 24 lines after Disconnect
```

Exit code 0 means reproduced, 1 means it did not. `--hold` keeps the session open afterwards, printing the debuggee's pid and line count once a second, so the suspended process can be inspected with `ps` instead of taken on trust.

To run it against this branch:

```bash
dotnet build                    -p:SharpDbgSourcePath=/path/to/sharpdbg
dotnet run --project src/Repro  -p:SharpDbgSourcePath=/path/to/sharpdbg
```

It references `SharpDbg.Infrastructure` directly and adds `Microsoft.Diagnostics.DbgShim`, which only the packaging project declares.

| | debuggee recovered |
|---|---|
| 0.1.9 | 0 of 3 runs |
| this branch | 3 of 3 runs |

`SharpDbg.Cli.Tests`: 30/30 on three consecutive runs with this applied. A fourth run hung before finishing, but the suite does that here on unmodified `main` too, so I read it as environmental rather than as a signal either way.

### Where this is reached without a deliberate throw

`HandleBreakpoint`'s own `ArgumentNullException.ThrowIfNull(managedBreakpoint)`, when a breakpoint hit arrives while that file's breakpoints are being replaced, and the decompilation failures behind stepping with `justMyCode` off. Both leave the debuggee suspended today.
