### PR TITLE
Launch an apphost directly instead of through the dotnet muxer

### DIFF
--- a/tests/SharpDbg.Cli.Tests/Helpers/DebugAdapterProcessHelper.cs
+++ b/tests/SharpDbg.Cli.Tests/Helpers/DebugAdapterProcessHelper.cs
@@ -85,6 +85,22 @@ public static class DebugAdapterProcessHelper
 		};
 	}
 
+	public static LaunchRequest GetLaunchRequest(string program, bool justMyCode = true)
+	{
+		return new LaunchRequest
+		{
+			ConfigurationProperties = new Dictionary<string, JToken>
+			{
+				["name"] = "LaunchRequestName",
+				["type"] = "coreclr",
+				["request"] = "launch",
+				["program"] = program,
+				["console"] = "internalConsole", // integratedTerminal and externalTerminal need a client that returns a process id
+				["justMyCode"] = justMyCode
+			}
+		};
+	}
+
 	public static SetBreakpointsRequest GetSetBreakpointsRequest(int? line = null, string? filePath = null)
 	{
 		line ??= 22;

--- a/tests/SharpDbg.Cli.Tests/Helpers/LaunchedDebuggeeKiller.cs
+++ b/tests/SharpDbg.Cli.Tests/Helpers/LaunchedDebuggeeKiller.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+
+namespace SharpDbg.Cli.Tests.Helpers;
+
+// A launched debuggee outlives its session - Dispose releases the Process object without killing it, and a
+// disconnect asking for termination does not return. Only processes that appeared afterwards are touched.
+public sealed class LaunchedDebuggeeKiller : IDisposable
+{
+	// An apphost runs under its own name, and a managed assembly runs under the muxer's
+	private static readonly string[] CandidateNames = ["DebuggableConsoleApp", "dotnet"];
+
+	private readonly HashSet<int> _preExistingProcessIds = GetCandidateProcessIds();
+
+	public void Dispose()
+	{
+		foreach (var processId in GetCandidateProcessIds().Except(_preExistingProcessIds))
+		{
+			try
+			{
+				using var process = Process.GetProcessById(processId);
+				process.Kill(entireProcessTree: true);
+			}
+			catch
+			{
+				// It already exited, or it is not ours to kill
+			}
+		}
+	}
+
+	private static HashSet<int> GetCandidateProcessIds()
+	{
+		var processIds = new HashSet<int>();
+		foreach (var name in CandidateNames)
+		{
+			foreach (var process in Process.GetProcessesByName(name))
+			{
+				using (process) processIds.Add(process.Id);
+			}
+		}
+		return processIds;
+	}
+}

--- a/tests/SharpDbg.Cli.Tests/LaunchTests.cs
+++ b/tests/SharpDbg.Cli.Tests/LaunchTests.cs
@@ -1,0 +1,49 @@
+using AwesomeAssertions;
+using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
+using SharpDbg.Cli.Tests.Helpers;
+
+namespace SharpDbg.Cli.Tests;
+
+public class LaunchTests(ITestOutputHelper testOutputHelper)
+{
+	private static string DebuggeeDirectory => Path.JoinFromGitRoot("artifacts", "bin", "DebuggableConsoleApp", "debug");
+
+	[Fact]
+	public async Task SharpDbgCli_LaunchManagedAssembly_StopsAtBreakpoint()
+	{
+		await LaunchAndStopAtBreakpoint(Path.Join(DebuggeeDirectory, "DebuggableConsoleApp.dll"));
+	}
+
+	// Handing an apphost to the muxer starts the muxer itself, which the debugger then attaches to instead of the program
+	[Fact]
+	public async Task SharpDbgCli_LaunchAppHost_StopsAtBreakpoint()
+	{
+		await LaunchAndStopAtBreakpoint(Path.Join(DebuggeeDirectory, OperatingSystem.IsWindows() ? "DebuggableConsoleApp.exe" : "DebuggableConsoleApp"));
+	}
+
+	private async Task LaunchAndStopAtBreakpoint(string program)
+	{
+		File.Exists(program).Should().BeTrue($"the debuggee must be built: {program}");
+
+		var (debugProtocolHost, initializedEventTcs, firstStoppedEventTcs, adapter) = TestHelper.GetRunningDebugProtocolHostForLaunchInProc(testOutputHelper);
+		using var _ = new LaunchedDebuggeeKiller(); // declared first so it runs last, on whatever survives the disconnect
+		using var __ = adapter;
+		using var ___ = debugProtocolHost;
+
+		await debugProtocolHost
+			.WithInitializeRequest()
+			.WithLaunchRequest(program)
+			.WaitForInitializedEvent(initializedEventTcs);
+
+		var breakpointedFilePath = Path.JoinFromGitRoot("tests", "DebuggableConsoleApp", "MyClass.cs");
+		await debugProtocolHost
+			.WithBreakpointsRequest([11], breakpointedFilePath)
+			.WithConfigurationDoneRequestAsync(); // the program is started here
+
+		var stoppedEvent = await firstStoppedEventTcs.Task.WaitAsync(TimeSpan.FromSeconds(60), TestContext.Current.CancellationToken);
+		stoppedEvent.Reason.Should().Be(StoppedEvent.ReasonValue.Breakpoint);
+		var (filePath, line, _) = stoppedEvent.ReadStopInfo();
+		filePath.Should().Be(breakpointedFilePath);
+		line.Should().Be(11);
+	}
+}

--- a/tests/SharpDbg.Cli.Tests/TestHelper.cs
+++ b/tests/SharpDbg.Cli.Tests/TestHelper.cs
@@ -32,6 +32,23 @@ public static partial class TestHelper
 		}
 	}
 
+	// No debuggee process - the debugger starts it. The first stop needs its own TaskCompletionSource:
+	// a launch binds and hits within milliseconds, and TcsContainer only holds the latest event.
+	public static (DisposableDebugProtocolHost, TaskCompletionSource InitializedEventTcs, TaskCompletionSource<StoppedEvent> FirstStoppedEventTcs, IDisposable DebugAdapterDisposable) GetRunningDebugProtocolHostForLaunchInProc(ITestOutputHelper testOutputHelper)
+	{
+		var (input, output, debugAdapterDisposable) = SharpDbgInMemory.NewDebugAdapterStreams(Log);
+		var initializedEventTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var debugProtocolHost = DebugAdapterProcessHelper.GetDebugProtocolHost(input, output, testOutputHelper, initializedEventTcs);
+		var firstStoppedEventTcs = new TaskCompletionSource<StoppedEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+		debugProtocolHost.RegisterEventType<StoppedEvent>(@event => firstStoppedEventTcs.TrySetResult(@event));
+		debugProtocolHost.Run();
+		return (debugProtocolHost, initializedEventTcs, firstStoppedEventTcs, debugAdapterDisposable);
+		void Log(string message)
+		{
+			testOutputHelper.WriteLine($"Log [SharpDbg]: {message}");
+		}
+	}
+
 	private static (DisposableDebugProtocolHost, TaskCompletionSource InitializedEventTcs, TcsContainer debugEventTcs, IDisposable DebugAdapterDisposable, Process DebuggableProcess) GetRunningDebugProtocolHostCore(ITestOutputHelper testOutputHelper, bool startSuspended, Stream input, Stream output, IDisposable debugAdapterDisposable)
 	{
 		var debuggableProcess = DebuggableProcessHelper.StartDebuggableProcess(startSuspended);
@@ -120,10 +137,26 @@ public static partial class TestHelper
 		return debugProtocolHost;
 	}
 
+	public static DebugProtocolHost WithLaunchRequest(this DebugProtocolHost debugProtocolHost, string program, bool justMyCode = true)
+	{
+		var launchRequest = DebugAdapterProcessHelper.GetLaunchRequest(program, justMyCode);
+		debugProtocolHost.SendRequestSync(launchRequest);
+		return debugProtocolHost;
+	}
+
 	public static DebugProtocolHost WithConfigurationDoneRequest(this DebugProtocolHost debugProtocolHost)
 	{
 		var configurationDoneRequest = new ConfigurationDoneRequest();
 		debugProtocolHost.SendRequestSync(configurationDoneRequest);
+		return debugProtocolHost;
+	}
+
+	// A launch runs inside configurationDone, so a program that cannot be started leaves the request
+	// unanswered - without a bound the whole run hangs instead of failing one test
+	public static async Task<DebugProtocolHost> WithConfigurationDoneRequestAsync(this DebugProtocolHost debugProtocolHost, int timeoutSeconds = 60)
+	{
+		var configurationDone = Task.Run(() => debugProtocolHost.SendRequestSync(new ConfigurationDoneRequest()), TestContext.Current.CancellationToken);
+		await configurationDone.WaitAsync(TimeSpan.FromSeconds(timeoutSeconds), TestContext.Current.CancellationToken);
 		return debugProtocolHost;
 	}
 


### PR DESCRIPTION
Fixes #33.

`PerformLaunch` and the `runInTerminal` request both hardcode the muxer:

```csharp
FileName = "dotnet",
ArgumentList = { launchInfo.Program },
```

```csharp
Arguments = ["dotnet", launchInfo.Program, ..launchInfo.Arguments],
```

That is right for a managed assembly and wrong for an apphost, which is the only artefact a self-contained or single-file publish produces.

It is worse than a failed launch. `dotnet <apphost>` does not fail fast - the muxer starts, fails to resolve the path as a command, and the debugger attaches to **the muxer** rather than to the program. The session looks healthy, and the top frame is:

```
dotnet.dll!Microsoft.DotNet.Cli.Telemetry.ExternalTelemetryProperties.GetLibcRelease()
```

`LaunchInfo.GetCommandLine()` now decides: a `.dll` goes through `dotnet`, anything else is run directly. Both call sites use it.

### Tests

`LaunchTests` launches `DebuggableConsoleApp` and stops at a breakpoint, once through the assembly and once through the apphost - the framework-dependent build produces both, so nothing new has to be published. On `main` the apphost case attaches to the muxer and never hits the breakpoint.

There was no launch coverage before, so this needed a little scaffolding:

- `GetRunningDebugProtocolHostForLaunchInProc` does not start a debuggee, and gives the first stop its own `TaskCompletionSource`. A launch binds its breakpoints and hits one within milliseconds, and the shared `TcsContainer` only holds the latest event, so the stop was getting dropped.
- `WithConfigurationDoneRequestAsync` bounds the request. The launch happens inside `configurationDone`, so a program the debugger cannot start leaves it unanswered - without a bound the whole run hangs instead of failing one test.
- `LaunchedDebuggeeKiller` kills what the launch started. `Dispose` releases the `Process` object without killing the process, and `disconnect` with `terminateDebuggee: true` does not return at all (below), so the test cannot hand cleanup back to the adapter.

### Unrelated, found on the way

`disconnect` with `terminateDebuggee: true`, sent while stopped at a breakpoint, never returns - 3 of 3 on `main`. With `terminateDebuggee: false` the same sequence disconnects cleanly, 2 of 2. It looks like the same lock as #32, but deterministic rather than 1-in-12, so it may be the easier way in. I have not touched it here.

Verified on macOS arm64 with .NET 10.

<!-- PR description above this line -->
#
> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/sharpdbg/blob/main/CONTRIBUTING.md#legal-notice)
