### PR TITLE
Do not throw on breakpoint event for a replaced breakpoint

### DIFF
--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
@@ -185,7 +185,12 @@ public partial class ManagedDebugger
 		}
 
 		var managedBreakpoint = _breakpointManager.FindByCorBreakpoint(functionBreakpoint);
-		ArgumentNullException.ThrowIfNull(managedBreakpoint);
+		if (managedBreakpoint is null)
+		{
+			_logger?.Invoke("Hit a breakpoint that has since been replaced - continuing");
+			ContinueWithVariableClear();
+			return;
+		}
 
 		managedBreakpoint.HitCount++;
 


### PR DESCRIPTION
`SetBreakpoints` deactivates the old `ICorDebugFunctionBreakpoint`s and drops the `BreakpointInfo`s that own them. A hit that was already in flight then finds nothing:

```csharp
var managedBreakpoint = _breakpointManager.FindByCorBreakpoint(functionBreakpoint);
ArgumentNullException.ThrowIfNull(managedBreakpoint);
```

`Activate(false)` cannot cancel a hit that has already happened — the process is frozen and the event is queued. The runtime callback does not take `DapRequestAndRuntimeEventLock` either, so draining the queue at the start of each request narrows the window without closing it: the event can land after the drain and before the replace.

Every other "not our case" branch in that method logs and continues, including the one for an unrecognised breakpoint type a few lines above. This does the same.

Re-sending one file's breakpoints every 20ms for 15s while the debuggee hits them, over `SharpDbgInMemory`:

| | throws | hits handled as replaced |
|---|---|---|
| 66db871 | 3–4 | — |
| with this | 0 | 1–6 |

**It is not a freeze on current main** — the failed-handler recovery catches the throw and continues the process, so the session survives. What is left is an ordinary race being reported as an unexpected failure and relying on a last-resort path: that recovery only continues if `TryIsRunning` returns `S_OK`, and it calls `Continue()` rather than `ContinueWithVariableClear()` like the rest of the method. On 0.1.9, before the recovery existed, the same hit froze the debuggee for good.

No test: reproducing it needs the 20ms churn above, and a test built on that timing would be flaky. Happy to add one if you can see a deterministic way in.

Rebased onto 534170d, `SharpDbg.Cli.Tests` 32 of 32.

*(This PR originally also made `_modules` a `ConcurrentDictionary`. Dropped — that could not be reproduced on 0.1.12, see the comments.)*

<!-- PR description above this line -->
#
> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/sharpdbg/blob/main/CONTRIBUTING.md#legal-notice)
