### PR TITLE
Stop the process before terminating it

### DIFF
--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
@@ -478,7 +478,10 @@ public partial class ManagedDebugger
 
 		// Unsubscribe from callbacks to avoid any further event dispatch
 		_callbacks.OnAnyEvent -= QueueEvent;
-		_runtimeEventChannel.Writer.Complete();
+		// TryComplete because this can run twice: Terminate disposes whether or not it succeeded, so a
+		// client that sends terminate and then disconnect would get a ChannelClosedException out of the
+		// second one
+		_runtimeEventChannel.Writer.TryComplete();
 		// ProcessRuntimeEventQueue is blocked on DapRequestAndRuntimeEventLock (which we hold) and would
 		// never complete if we waited on it here — that is the deadlock. Read and discard remaining events ourselves,
 		// then let the processor exit once the lock is released.

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_RequestHandlers.cs
@@ -648,6 +648,15 @@ public partial class ManagedDebugger
 		{
 			try
 			{
+				// Terminate needs the process synchronized. On a running one it fails with
+				// CORDBG_E_PROCESS_NOT_SYNCHRONIZED and leaves the debuggee running.
+				if (_process.TryIsRunning(out var isRunning) is Cor.S_OK && isRunning)
+				{
+					var stopHResult = _process.TryStop(0);
+					if (stopHResult is not (Cor.S_OK or Cor.CORDBG_E_PROCESS_TERMINATED))
+						_logger?.Invoke($"Error stopping process before terminating it: {stopHResult}");
+				}
+
 				_process.Terminate(0);
 			}
 			catch (Exception ex)


### PR DESCRIPTION
Fixes #38.

`ICorDebugProcess::Terminate` needs the process synchronized. On a running debuggee it fails with `CORDBG_E_PROCESS_NOT_SYNCHRONIZED (0x80131302)`, the exception is caught and logged, and the request answers success while the process keeps running. Stopping first is what `Disconnect` already does on its other branch, so this reuses the same `TryIsRunning`/`TryStop` pair.

The second change is `TryComplete` instead of `Complete` on the runtime event channel. `Terminate()` disposes whether or not the terminate worked, so `terminate` followed by `disconnect` disposes twice and the second one throws `ChannelClosedException` out of `Dispose`, surfaced as `Failed to disconnect`.

Measured over `SharpDbgInMemory` + `DebugProtocolHost`, launching a console app and killing it four ways:

| what the client sends | 534170d | with this |
|---|---|---|
| `terminate` while stopped at a breakpoint | killed | killed |
| `disconnect(terminateDebuggee: true)` while stopped | killed | killed |
| `terminate` while running | survives | **killed** |
| `disconnect(terminateDebuggee: true)` while running | survives | **killed** |

And `disconnect` after a `terminate` no longer fails.

`SharpDbg.Cli.Tests` 32 of 32, three times, and 32 of 32 on 534170d as a control. Two runs failed on the way there, one on each side. The one I captured is on your main rather than on this branch, and it is the environment: `ServerNotAvailableException` for a stale `dotnet-diagnostic-*-socket` in `$TMPDIR`. Every debuggee killed rather than detached leaves one behind, and after a while the next attach cannot connect - I had 129 dead ones to clear before the suite was reliable again.

No test: it needs a launched debuggee, and the only launch scaffolding is in #34. Once that lands this is a few lines on top of `LaunchTests` - happy to add it there, or here if you would rather have the test first.

<!-- PR description above this line -->
#
> I agree to the terms of contributing as stated [here](https://github.com/MattParkerDev/sharpdbg/blob/main/CONTRIBUTING.md#legal-notice)
