### PR TITLE
Report the exit code of a program we launched

### DIFF
--- a/src/SharpDbg.Application/DebugAdapter.cs
+++ b/src/SharpDbg.Application/DebugAdapter.cs
@@ -171,11 +171,12 @@ public class DebugAdapter : DebugAdapterBase
 			});
 		};
 
-		_debugger.OnExited += () =>
+		_debugger.OnExited += exitCode =>
 		{
 			Protocol.SendEvent(new ExitedEvent
 			{
-				ExitCode = 0 // There is no built-in, cross-platform way to get the exit code of an exited process
+				// Null when we attached: the exit code of a process we did not start is not ours to read
+				ExitCode = exitCode ?? 0
 			});
 		};
 

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger.cs
@@ -39,7 +39,8 @@ public partial class ManagedDebugger
 	// ThreadId, FilePath, Line, Column, Reason, HitBreakpointIds, DecompiledSourceInfo
 	public event Action<int, string, int, int, string, List<int>?, DecompiledSourceInfo?>? OnStopped2;
 	public event Action<int>? OnContinued;
-	public event Action? OnExited;
+	// Exit code, or null when it cannot be known - we attached rather than launched
+	public event Action<int?>? OnExited;
 	public event Action? OnTerminated;
 	public event Action<int>? OnThreadStarted;
 	public event Action<int>? OnThreadExited;

--- a/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
+++ b/src/SharpDbg.Infrastructure/Debugger/ManagedDebugger_EventHandlers.cs
@@ -22,7 +22,12 @@ public partial class ManagedDebugger
 	private void HandleProcessExited(object? sender, ExitProcessCorDebugManagedCallbackEventArgs exitProcessCorDebugManagedCallbackEventArgs)
 	{
 		_logger?.Invoke($"Process exited");
-		OnExited?.Invoke();
+
+		// Read here rather than letting a subscriber ask later: Dispose releases _debuggeeProcess, and
+		// a process we launched has already been reaped by the time this callback runs
+		var exitCode = _debuggeeProcess?.HasExited == true ? _debuggeeProcess.ExitCode : (int?)null;
+
+		OnExited?.Invoke(exitCode);
 		OnTerminated?.Invoke();
 	}
 


### PR DESCRIPTION
Fixes #42.

`ExitedEvent` carried a hardcoded 0, on the grounds that there is no cross-platform way to read the exit code of an exited process. True for a process we attached to, not for one we started: `PerformLaunch` keeps it in `_debuggeeProcess`, and `Process.ExitCode` works everywhere once it has exited.

The value travels on `OnExited` rather than being read by the subscriber. `_debuggeeProcess` is private to `ManagedDebugger` and the event is consumed in `DebugAdapter`, and `Dispose` releases it, so the callback is the only safe place to read it. Same shape as `OnProcessStarted` in bb9fefa.

`int?` separates "we attached, so this is not ours to read" from "the program returned 0". Attach keeps sending 0.

Measured with a debuggee whose last statement is `return 7`, driven over `SharpDbgInMemory` + `DebugProtocolHost`:

| | `ExitedEvent.ExitCode` |
|---|---|
| before | 0, 11 runs |
| after | 7, 8 runs |

Both a `.dll` and an apphost, in each case. Your suite is 32/32. I also ran the suite of the MCP server I maintain against this branch — 140 tests, most of them attach-and-detach — to check the attach path is untouched.

No test here: there is no launch coverage in the repo to hang one on. Happy to add one if you want it, though it drags in a launch harness.
